### PR TITLE
wip: feat: Add namespace selector for admission controller

### DIFF
--- a/cmd/admission/main.go
+++ b/cmd/admission/main.go
@@ -125,8 +125,10 @@ func main() {
 		os.Exit(1)
 	}
 	podAdmission := admission.PodAdmission{
-		ManagedNamespaces: cfg.ManagedNamespaces,
-		SchedulerName:     cfg.SchedulerName,
+		Client:                   mgr.GetClient(),
+		ManagedNamespaces:        cfg.ManagedNamespaces,
+		ManagedNamespaceSelector: cfg.ManagedNamespaceSelector,
+		SchedulerName:            cfg.SchedulerName,
 	}
 	if err := podAdmission.SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Pod")

--- a/docs/admission.md
+++ b/docs/admission.md
@@ -24,7 +24,9 @@ Any pods created in certain namespaces will have their `.spec.schedulerName`
 changed to our [scheduler].
 
 Managed namespaces are defined as a list of namespace as configured in the
-admission controller's `values.yaml` for `managedNamespaces[]`.
+admission controller's `values.yaml` for `managedNamespaces[]`. Alternatively,
+a `managedNamespaceSelector` can be used to select namespaces based on labels.
+If `managedNamespaceSelector` is set, `managedNamespaces` will be ignored.
 
 ### Sequence Diagram
 

--- a/helm/slurm-bridge/templates/configmap.yaml
+++ b/helm/slurm-bridge/templates/configmap.yaml
@@ -14,9 +14,14 @@ data:
   config.yaml: |
     schedulerName: {{ include "slurm-bridge.scheduler.name" . }}
     slurmRestApi: {{ .Values.sharedConfig.slurmRestApi }}
+    {{- if .Values.admission.managedNamespaceSelector }}
+    managedNamespaceSelector:
+      {{- toYaml .Values.admission.managedNamespaceSelector | nindent 6 }}
+    {{- else }}
     managedNamespaces:
     {{- range .Values.admission.managedNamespaces }}
       - {{ . }}
+    {{- end }}
     {{- end }}
     mcsLabel: {{ .Values.schedulerConfig.mcsLabel }}
     partition: {{ .Values.schedulerConfig.partition }}

--- a/helm/slurm-bridge/values.yaml
+++ b/helm/slurm-bridge/values.yaml
@@ -162,6 +162,12 @@ admission:
   managedNamespaces: []
     # - managedNamespace1
     # - managedNamespace2
+  #
+  # -- (object)
+  # A label selector to select namespaces to be monitored by the pod admission controller.
+  # If this is set, managedNamespaces will be ignored.
+  # Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+  managedNamespaceSelector: {}
 
 #
 # Configuration settings for the controllers.

--- a/internal/admission/admission.go
+++ b/internal/admission/admission.go
@@ -10,17 +10,21 @@ import (
 
 	"github.com/SlinkyProject/slurm-bridge/internal/wellknown"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 type PodAdmission struct {
-	SchedulerName     string
-	ManagedNamespaces []string `yaml:"managedNamespaces"`
+	Client                   client.Client
+	SchedulerName            string
+	ManagedNamespaces        []string
+	ManagedNamespaceSelector *metav1.LabelSelector
 }
 
 func (r *PodAdmission) SetupWebhookWithManager(mgr ctrl.Manager) error {
@@ -42,9 +46,15 @@ func (r *PodAdmission) Default(ctx context.Context, obj runtime.Object) error {
 		return fmt.Errorf("expected a Pod but got a %T", obj)
 	}
 	logger.V(1).Info("Defaulting", "pod", klog.KObj(pod), "pod.Spec.SchedulerName", pod.Spec.SchedulerName)
-	if !r.isManagedNamespace(pod.Namespace) {
+
+	isManaged, err := r.isManagedNamespace(ctx, pod.Namespace)
+	if err != nil {
+		return err
+	}
+	if !isManaged {
 		return nil
 	}
+
 	if pod.Spec.SchedulerName == corev1.DefaultSchedulerName {
 		pod.Spec.SchedulerName = r.SchedulerName
 	}
@@ -62,7 +72,11 @@ func (r *PodAdmission) ValidateCreate(ctx context.Context, obj runtime.Object) (
 		return nil, fmt.Errorf("expected a Pod but got a %T", obj)
 	}
 	logger.V(1).Info("ValidateCreate", "pod", klog.KObj(pod))
-	if !r.isManagedNamespace(pod.Namespace) {
+	isManaged, err := r.isManagedNamespace(ctx, pod.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	if !isManaged {
 		return nil, nil
 	}
 	if pod.Labels[wellknown.LabelPlaceholderJobId] != "" {
@@ -79,7 +93,11 @@ func (r *PodAdmission) ValidateUpdate(ctx context.Context, oldObj runtime.Object
 	newPod := newObj.(*corev1.Pod)
 	oldPod := oldObj.(*corev1.Pod)
 	logger.V(1).Info("ValidateUpdate", "newPod", klog.KObj(newPod), "oldPod", klog.KObj(oldPod))
-	if !r.isManagedNamespace(newPod.Namespace) {
+	isManaged, err := r.isManagedNamespace(ctx, newPod.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	if !isManaged {
 		return nil, nil
 	}
 	// Once a pod has been placed by the Slurm bridge scheduler the jobid and
@@ -102,6 +120,22 @@ func (r *PodAdmission) ValidateDelete(ctx context.Context, obj runtime.Object) (
 	return nil, nil
 }
 
-func (r *PodAdmission) isManagedNamespace(namespace string) bool {
-	return slices.Contains(r.ManagedNamespaces, namespace)
+func (r *PodAdmission) isManagedNamespace(ctx context.Context, namespace string) (bool, error) {
+	if r.ManagedNamespaceSelector != nil {
+		selector, err := metav1.LabelSelectorAsSelector(r.ManagedNamespaceSelector)
+		if err != nil {
+			return false, fmt.Errorf("error creating label selector: %w", err)
+		}
+		nsList := &corev1.NamespaceList{}
+		if err := r.Client.List(ctx, nsList, &client.ListOptions{LabelSelector: selector}); err != nil {
+			return false, fmt.Errorf("error listing namespaces: %w", err)
+		}
+		for _, ns := range nsList.Items {
+			if ns.Name == namespace {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+	return slices.Contains(r.ManagedNamespaces, namespace), nil
 }

--- a/internal/admission/admission_test.go
+++ b/internal/admission/admission_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -522,6 +523,105 @@ func TestPodAdmission_ValidateDelete(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("PodAdmission.ValidateDelete() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPodAdmission_NamespaceSelector(t *testing.T) {
+	tests := []struct {
+		name                     string
+		managedNamespaceSelector *metav1.LabelSelector
+		managedNamespaces        []string
+		namespace                *corev1.Namespace
+		pod                      *corev1.Pod
+		expectedManaged          bool
+	}{
+		{
+			name: "namespace matches selector",
+			managedNamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"managed": "true"},
+			},
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "managed-ns",
+					Labels: map[string]string{"managed": "true"},
+				},
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "managed-ns",
+				},
+				Spec: corev1.PodSpec{
+					SchedulerName: corev1.DefaultSchedulerName,
+				},
+			},
+			expectedManaged: true,
+		},
+		{
+			name: "namespace does not match selector",
+			managedNamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"managed": "true"},
+			},
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "unmanaged-ns",
+					Labels: map[string]string{"managed": "false"},
+				},
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "unmanaged-ns",
+				},
+				Spec: corev1.PodSpec{
+					SchedulerName: corev1.DefaultSchedulerName,
+				},
+			},
+			expectedManaged: false,
+		},
+		{
+			name:              "selector is nil, fallback to managedNamespaces",
+			managedNamespaces: []string{"managed-ns"},
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "managed-ns",
+				},
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "managed-ns",
+				},
+				Spec: corev1.PodSpec{
+					SchedulerName: corev1.DefaultSchedulerName,
+				},
+			},
+			expectedManaged: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(tt.namespace).Build()
+			r := &PodAdmission{
+				Client:                   fakeClient,
+				SchedulerName:            SchedulerName,
+				ManagedNamespaces:        tt.managedNamespaces,
+				ManagedNamespaceSelector: tt.managedNamespaceSelector,
+			}
+
+			err := r.Default(context.TODO(), tt.pod)
+			if err != nil {
+				t.Fatalf("Default() returned an unexpected error: %v", err)
+			}
+
+			if tt.expectedManaged {
+				if tt.pod.Spec.SchedulerName != SchedulerName {
+					t.Errorf("expected scheduler name to be %q, but got %q", SchedulerName, tt.pod.Spec.SchedulerName)
+				}
+			} else {
+				if tt.pod.Spec.SchedulerName == SchedulerName {
+					t.Errorf("expected scheduler name not to be %q, but it was", SchedulerName)
+				}
 			}
 		})
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,8 @@
 package config
 
 import (
-	yaml "gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -12,11 +13,12 @@ const (
 )
 
 type Config struct {
-	SchedulerName     string   `yaml:"schedulerName"`
-	SlurmRestApi      string   `yaml:"slurmRestApi"`
-	ManagedNamespaces []string `yaml:"managedNamespaces"`
-	MCSLabel          string   `yaml:"mcsLabel"`
-	Partition         string   `yaml:"partition"`
+	SchedulerName            string                `yaml:"schedulerName"`
+	SlurmRestApi             string                `yaml:"slurmRestApi"`
+	ManagedNamespaces        []string              `yaml:"managedNamespaces"`
+	ManagedNamespaceSelector *metav1.LabelSelector `yaml:"managedNamespaceSelector"`
+	MCSLabel                 string                `yaml:"mcsLabel"`
+	Partition                string                `yaml:"partition"`
 }
 
 func Unmarshal(in []byte) (*Config, error) {


### PR DESCRIPTION
This commit introduces a new feature that allows administrators to configure the admission controller to manage namespaces using a label selector.

This provides a more flexible and scalable way to manage namespaces than the previous method of using a static list of namespace names.

The following changes are included:

- The `Config` struct has been updated to include a `ManagedNamespaceSelector` field.
- The admission controller now uses the `ManagedNamespaceSelector` to determine which namespaces to manage. If the selector is not provided, it falls back to the existing `ManagedNamespaces` list.
- The Helm chart and documentation have been updated to reflect the new feature.
- Unit tests have been added to verify the new functionality.

Aims to address #4 