### PR TITLE
Rename secret for token authentication

### DIFF
--- a/helm/slurm-bridge/values.yaml
+++ b/helm/slurm-bridge/values.yaml
@@ -230,4 +230,4 @@ sharedConfig:
   #
   # -- (string)
   # The secret containing a SLURM_JWT token for authentication.
-  slurmJwtSecret: slurm-bridge-jwt-token
+  slurmJwtSecret: slurm-bridge-token


### PR DESCRIPTION
There is a small bug when installing the Helm Charts with the default value and working with the Slurm operator.

```
Error: secrets "slurm-bridge-jwt-token" not found
```

This error is due to the wrong naming of the secret, which is labeled as `slurm-bridge-token`, inside the quickstart: https://github.com/SlinkyProject/slurm-bridge/blob/main/docs/quickstart.md#2-create-a-secret-for-slurm-bridge

```
kubectl apply -f - <<EOF
apiVersion: slinky.slurm.net/v1alpha1
kind: Token
metadata:
  name: slurm-bridge-token
  namespace: slinky
spec:
  jwtHs256KeyRef:
    name: slurm-auth-jwths256
    key: jwt_hs256.key
    namespace: slurm
  secretRef:
    name: slurm-bridge-token
    key: auth-token
  username: slurm
  refresh: true
  lifetime: 8760h
EOF
```

I choose to rename it here, but it could be rather in the quickstare