### PR TITLE
Fix - rename secret in slurm-bridge documentation

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -102,7 +102,7 @@ When running Slurm on baremetal:
 ```sh
 export $(scontrol token username=slurm lifespan=infinite)
 kubectl create namespace slurm-bridge
-kubectl create secret generic slurm-bridge-jwt-token --namespace=slinky --from-literal="auth-token=$SLURM_JWT" --type=Opaque
+kubectl create secret generic slurm-bridge-token --namespace=slinky --from-literal="auth-token=$SLURM_JWT" --type=Opaque
 ```
 
 ##### 2. Download and configure `values.yaml` for the `slurm-bridge` helm chart


### PR DESCRIPTION
<!--
Feature requests, code contributions, and bug reports are welcome!
Github/Gitlab submitted issues and PRs/MRs are handled on a best effort basis.
The SchedMD official issue tracker is at <https://support.schedmd.com/>.
-->

## Summary

The secret name in the documentation does not match the one used and expected by the helm chart.

Simple to reproduce:

1. Create token

```
[bluebanquise@mgt2 ~]$ export $(sudo scontrol token username=slurm lifespan=infinite)
[bluebanquise@mgt2 ~]$ kubectl create secret generic slurm-bridge-jwt-token --namespace=slinky --from-literal="auth-token=$SLURM_JWT" --type=Opaque
secret/slurm-bridge-jwt-token created
[bluebanquise@mgt2 ~]$
``` 

2. Push helm chart

```
[bluebanquise@mgt2 ~]$ helm install slurm-bridge oci://ghcr.io/slinkyproject/charts/slurm-bridge   --namespace=slinky --create-namespace
Pulled: ghcr.io/slinkyproject/charts/slurm-bridge:1.0.1
Digest: sha256:559e6189983bbdec36277afe63545cad7b539abc9d2b1f39cc01c083fe253e15
I0114 16:30:22.566529 2277208 warnings.go:110] "Warning: spec.SessionAffinity is ignored for headless services"
NAME: slurm-bridge
LAST DEPLOYED: Wed Jan 14 16:30:21 2026
NAMESPACE: slinky
STATUS: deployed
REVISION: 1
TEST SUITE: None
[bluebanquise@mgt2 ~]$
```

Then you can see that containers are in error. Checking description shows this:

```
  Type     Reason       Age                From               Message
  ----     ------       ----               ----               -------
  Normal   Scheduled    37s                default-scheduler  Successfully assigned slinky/slurm-bridge-admission-748565b758-mqksn to w001
  Warning  FailedMount  34s (x4 over 37s)  kubelet            MountVolume.SetUp failed for volume "certificates" : secret "slurm-bridge-admission" not found
  Normal   Pulling      29s                kubelet            Pulling image "ghcr.io/slinkyproject/slurm-bridge-admission:1.0.1"
  Normal   Pulled       22s                kubelet            Successfully pulled image "ghcr.io/slinkyproject/slurm-bridge-admission:1.0.1" in 3.295s (6.478s including waiting). Image size: 21915446 bytes.
  Warning  Failed       10s (x3 over 22s)  kubelet            Error: secret "slurm-bridge-token" not found
  Normal   Pulled       10s (x2 over 22s)  kubelet            Container image "ghcr.io/slinkyproject/slurm-bridge-admission:1.0.1" already present on machine
```

So solution is just to push the token into a secret with container expected name.

## Breaking Changes

None

## Testing Notes

See previous description

## Additional Context

Bare metal cluster, deployed using BlueBanquise stack, Slurm 25.05.5, RockyLinux 9. Kubernetes deployed via Kubespray, v1.34.0
