### PR TITLE
rbac: add resourceclaims/binding for DRA granular status authorization

### DIFF
--- a/helm/slurm-bridge/templates/scheduler/rbac.yaml
+++ b/helm/slurm-bridge/templates/scheduler/rbac.yaml
@@ -89,6 +89,9 @@ rules:
   resources: ["resourceclaims/status"]
   verbs: ["patch", "update"]
 - apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims/binding"]
+  verbs: ["update", "patch"]
+- apiGroups: ["resource.k8s.io"]
   resources: ["deviceclasses", "resourceslices"]
   verbs: ["get", "list", "watch"]
 ---


### PR DESCRIPTION
Starting in Kubernetes v1.36, the `DRAResourceClaimGranularStatusAuthorization` feature gate (beta, on-by-default) enforces fine-grained authorization checks for `ResourceClaim` status updates.

Schedulers that modify `status.allocation` or `status.reservedFor` now require additional permissions on the `resourceclaims/binding` synthetic subresource.

This adds the required RBAC rule for the Slurm Bridge scheduler. The existing `resourceclaims/status` permission is still required and remains unchanged.

These new permissions are inert on Kubernetes versions prior to v1.36, so this is safe to merge now in preparation.

Ref: kubernetes/kubernetes#138149