### PR TITLE
rbac: Add pods/finalizers permission to scheduler role

### DIFF
--- a/config/rbac/scheduler/role.yaml
+++ b/config/rbac/scheduler/role.yaml
@@ -61,6 +61,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/finalizers
   - pods/status
   verbs:
   - patch

--- a/helm/slurm-bridge/files/scheduler_rbac_rules.yaml
+++ b/helm/slurm-bridge/files/scheduler_rbac_rules.yaml
@@ -56,6 +56,7 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - pods/finalizers
       - pods/status
     verbs:
       - patch

--- a/internal/scheduler/plugins/slurmbridge/slurmbridge.go
+++ b/internal/scheduler/plugins/slurmbridge/slurmbridge.go
@@ -62,6 +62,7 @@ func init() {
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch;update
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;patch;watch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=delete;get;list;patch;watch
+// +kubebuilder:rbac:groups="",resources=pods/finalizers,verbs=patch;update
 // +kubebuilder:rbac:groups="",resources=pods/status,verbs=patch;update
 // +kubebuilder:rbac:groups="",resources=bindings,verbs=create
 // +kubebuilder:rbac:groups="",resources=pods/binding,verbs=create


### PR DESCRIPTION


<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->

<!--
Feature requests, code contributions, and bug reports are welcome!
GitHub issues and pull requests are handled on a best-effort basis.
The SchedMD official issue tracker is at <https://support.schedmd.com/>.
-->

## Summary
The scheduler needs permission to patch and update pod finalizers in addition to pod status. This adds the pods/finalizers resource to the RBAC rules in the kube config, Helm chart, and kubebuilder markers.

Fixes #19 

## Checklist

- [x] I have read
  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-bridge/blob/main/CONTRIBUTING.md)
  and the
  [Code of Conduct](https://github.com/SlinkyProject/slurm-bridge/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes.

## Breaking Changes

<!--
Does this cause any breaking changes to users?
Explain why the breakage has to happen.
-->

## Testing Notes

For OCP 4.21, I just install slurm + slurm-bridge.

I submit a job to the bridge-scheduler. I see pods don't get scheduled and reading the logs I saw this rbac error.
<!--
How to test this change.
-->

## Additional Context

<!--
Any other context for reviewers.
-->
