### PR TITLE
add priority as a well known annotation for slurm-bridge

### DIFF
--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -100,6 +100,7 @@ see the [annotations.go] source.
 | slurmjob.slinky.slurm.net/max-nodes    | Sets the maximum number of nodes. | "3"          |
 | slurmjob.slinky.slurm.net/mem-per-node | Sets the amount of memory.        | "8Gi"        |
 | slurmjob.slinky.slurm.net/partition    | Overrides the default partition.  | "debug"      |
+| slurmjob.slinky.slurm.net/priority    | Sets the job priority.            | "100"        |
 
 An example of the annotations in use:
 

--- a/internal/scheduler/plugins/slurmbridge/slurmcontrol/slurmcontrol.go
+++ b/internal/scheduler/plugins/slurmbridge/slurmcontrol/slurmcontrol.go
@@ -192,6 +192,17 @@ func (r *realSlurmControl) submitJob(ctx context.Context, pod *corev1.Pod, slurm
 			Name:          slurmJobIR.JobInfo.JobName,
 			Nodes:         ptr.To(strconv.Itoa(len(slurmJobIR.Pods.Items))),
 			RequiredNodes: ptr.To(api.V0044CsvString(slurmJobIR.JobInfo.Nodes)),
+			Priority: func() *api.V0044Uint32NoValStruct {
+				if slurmJobIR.JobInfo.Priority != nil {
+					return &api.V0044Uint32NoValStruct{
+						Infinite: ptr.To(false),
+						Number:   slurmJobIR.JobInfo.Priority,
+						Set:      ptr.To(true),
+					}
+				} else {
+					return &api.V0044Uint32NoValStruct{Set: ptr.To(false)}
+				}
+			}(),
 			Partition: func() *string {
 				if slurmJobIR.JobInfo.Partition == nil {
 					return &r.partition

--- a/internal/scheduler/plugins/slurmbridge/slurmcontrol/slurmcontrol_test.go
+++ b/internal/scheduler/plugins/slurmbridge/slurmcontrol/slurmcontrol_test.go
@@ -510,6 +510,39 @@ func Test_realSlurmControl_SubmitJob(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Submit external job with priority",
+			fields: fields{
+				Client: func() client.Client {
+					f := interceptor.Funcs{
+						Create: func(ctx context.Context, obj object.Object, req any, opts ...client.CreateOption) error {
+							obj.(*slurmtypes.V0044JobInfo).JobId = ptr.To(int32(1))
+							jobSubmit := req.(api.V0044JobSubmitReq)
+							if jobSubmit.Job == nil || jobSubmit.Job.Priority == nil {
+								return fmt.Errorf("expected Priority to be set, got nil")
+							}
+							if !ptr.Deref(jobSubmit.Job.Priority.Set, false) {
+								return fmt.Errorf("expected Priority.Set to be true")
+							}
+							if ptr.Deref(jobSubmit.Job.Priority.Number, 0) != 100 {
+								return fmt.Errorf("expected Priority.Number=100, got %d", ptr.Deref(jobSubmit.Job.Priority.Number, 0))
+							}
+							return nil
+						},
+					}
+					return fake.NewClientBuilder().
+						WithInterceptorFuncs(f).
+						Build()
+				}(),
+			},
+			args: args{
+				ctx:        context.Background(),
+				pod:        st.MakePod().Name("foo").Namespace("slurm-bridge").Obj(),
+				slurmJobIR: &slurmjobir.SlurmJobIR{JobInfo: slurmjobir.SlurmJobIRJobInfo{Priority: ptr.To(int32(100))}},
+			},
+			want:    1,
+			wantErr: false,
+		},
+		{
 			name: "Submit external job slurmJobIR.Exclusive false yields empty Shared (non-exclusive)",
 			fields: fields{
 				Client: func() client.Client {

--- a/internal/utils/slurmjobir/slurmjobir.go
+++ b/internal/utils/slurmjobir/slurmjobir.go
@@ -40,6 +40,7 @@ type SlurmJobIRJobInfo struct {
 	MaxNodes     *int32
 	Nodes        []string
 	Partition    *string
+	Priority     *int32
 	QOS          *string
 	Reservation  *string
 	TasksPerNode *int32
@@ -225,6 +226,12 @@ func parseAnnotations(slurmJobIR *SlurmJobIR, anno map[string]string) error {
 			slurmJobIR.JobInfo.MinNodes = num
 		case wellknown.AnnotationPartition:
 			slurmJobIR.JobInfo.Partition = &value
+		case wellknown.AnnotationPriority:
+			num, err := ConvStrTo32(value)
+			if err != nil {
+				return err
+			}
+			slurmJobIR.JobInfo.Priority = num
 		case wellknown.AnnotationQOS:
 			slurmJobIR.JobInfo.QOS = &value
 		case wellknown.AnnotationReservation:

--- a/internal/utils/slurmjobir/slurmjobir_test.go
+++ b/internal/utils/slurmjobir/slurmjobir_test.go
@@ -408,6 +408,7 @@ func Test_parseAnnotations(t *testing.T) {
 					wellknown.AnnotationMemPerNode:  "1Gi",
 					wellknown.AnnotationMinNodes:    "2",
 					wellknown.AnnotationPartition:   "slurm-bridge",
+					wellknown.AnnotationPriority:    "100",
 					wellknown.AnnotationQOS:         "high",
 					wellknown.AnnotationReservation: "training",
 					wellknown.AnnotationTimeLimit:   "30",
@@ -429,6 +430,7 @@ func Test_parseAnnotations(t *testing.T) {
 					MinNodes:    ptr.To(int32(2)),
 					MaxNodes:    ptr.To(int32(4)),
 					Partition:   ptr.To("slurm-bridge"),
+					Priority:    ptr.To(int32(100)),
 					QOS:         ptr.To("high"),
 					Reservation: ptr.To("training"),
 					TimeLimit:   ptr.To(int32(30)),
@@ -473,6 +475,16 @@ func Test_parseAnnotations(t *testing.T) {
 				slurmJobIR: &SlurmJobIR{},
 				anno: map[string]string{
 					wellknown.AnnotationTimeLimit: "foo",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "BadPriorityAnnotation",
+			args: args{
+				slurmJobIR: &SlurmJobIR{},
+				anno: map[string]string{
+					wellknown.AnnotationPriority: "foo",
 				},
 			},
 			wantErr: true,

--- a/internal/wellknown/annotations.go
+++ b/internal/wellknown/annotations.go
@@ -54,6 +54,9 @@ const (
 	// AnnotationPartitions overrides the default partition
 	// for the Slurm external job.
 	AnnotationPartition = SlurmJobPrefix + "partition"
+	// AnnotationPriority sets the priority
+	// for the Slurm external job.
+	AnnotationPriority = SlurmJobPrefix + "priority"
 	// AnnotationQOS overrides the default QOS
 	// for the Slurm external job.
 	AnnotationQOS = SlurmJobPrefix + "qos"


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->

<!--
Feature requests, code contributions, and bug reports are welcome!
GitHub issues and pull requests are handled on a best-effort basis.
The SchedMD official issue tracker is at <https://support.schedmd.com/>.
-->

## Summary

Fixes: https://github.com/SlinkyProject/slurm-bridge/issues/23
<!--
Describe what this is for and why it is needed.
Link relevant issues which this addresses (e.g. closes #123).
-->

## Checklist

- [x] I have read
  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-bridge/blob/main/CONTRIBUTING.md)
  and the
  [Code of Conduct](https://github.com/SlinkyProject/slurm-bridge/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes.

## Breaking Changes

No.

## Testing Notes

Add `slurmjob.slinky.slurm.net/priority: "10000"` to a job.

```yaml
---
apiVersion: batch/v1
kind: Job
metadata:
  name: job-sleep-minow
  namespace: test-slurm
  # slurm-bridge annotations on parent object
  annotations:
    slinky.slurm.net/job-name: job-sleep-minow
    slurmjob.slinky.slurm.net/account: slurm
    slurmjob.slinky.slurm.net/partition: all
    slurmjob.slinky.slurm.net/timelimit: "1"
    slurmjob.slinky.slurm.net/priority: "10000"
spec:
  completions: 1
  parallelism: 1
  template:
    spec:
      containers:
        - name: sleep
          image: quay.io/prometheus/busybox
          command: [sh, -c, sleep 30000]
          resources:
            requests:
              cpu: '3'
              memory: 100Mi
            limits:
              cpu: '3'
              memory: 100Mi
      restartPolicy: Never
```

Checking the `scontrol show job` I can see that priority is correctly passed into Slurm.

```
kehannon@kehannon-thinkpadp1gen4i:~/Work/slurm-kueue-ocp/examples$ k exec -n slurm slurm-controller-0 -- scontrol show job 2
JobId=2 JobName=(null)
   UserId=slurm(401) GroupId=slurm(401) MCS_label=kubernetes
   Priority=10000 Nice=0 Account=slurm QOS=(null)
```

## Additional Context

