### PR TITLE
fix: nodeSelector and affinity

### DIFF
--- a/helm/slurm-bridge/templates/admission/deployment.yaml
+++ b/helm/slurm-bridge/templates/admission/deployment.yaml
@@ -47,12 +47,6 @@ spec:
           {{- with .Values.admission.resources }}
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.admission.nodeSelector }}
-          nodeSelector: {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.admission.affinity }}
-          affinity: {{- toYaml . | nindent 12 }}
-          {{- end }}
           volumeMounts:
             - name: certificates
               mountPath: /tmp/k8s-webhook-server/serving-certs/
@@ -60,6 +54,12 @@ spec:
             - name: slurm-bridge-config
               mountPath: /etc/slurm-bridge/
               readOnly: true
+      {{- with .Values.admission.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admission.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.admission.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm/slurm-bridge/templates/controllers/deployment.yaml
+++ b/helm/slurm-bridge/templates/controllers/deployment.yaml
@@ -49,16 +49,16 @@ spec:
           {{- with .Values.admission.resources }}
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.controllers.nodeSelector }}
-          nodeSelector: {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.controllers.affinity }}
-          affinity: {{- toYaml . | nindent 12 }}
-          {{- end }}
           volumeMounts:
             - name: slurm-bridge-config
               mountPath: /etc/slurm-bridge/
               readOnly: true
+      {{- with .Values.controllers.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controllers.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.controllers.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm/slurm-bridge/templates/scheduler/deployment.yaml
+++ b/helm/slurm-bridge/templates/scheduler/deployment.yaml
@@ -51,12 +51,6 @@ spec:
             path: /healthz
             port: 10259
             scheme: HTTPS
-        {{- with .Values.scheduler.nodeSelector }}
-        nodeSelector: {{- toYaml . | nindent 10 }}
-        {{- end }}
-        {{- with .Values.scheduler.affinity }}
-        affinity: {{- toYaml . | nindent 10 }}
-        {{- end }}
         {{- with .Values.scheduler.resources }}
         resources: {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -71,6 +65,12 @@ spec:
           readOnly: true
       hostNetwork: false
       hostPID: false
+      {{- with .Values.scheduler.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scheduler.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.scheduler.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->

## Summary

This commit fixes nodeSelector: and affinity: indentation in deployment templates.

## Checklist

- [ X] I have read
  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-bridge/blob/main/CONTRIBUTING.md)
  and the
  [Code of Conduct](https://github.com/SlinkyProject/slurm-bridge/blob/main/CODE_OF_CONDUCT.md).
- [ X] New or existing tests cover these changes (where applicable).
 - [ ] Documentation is updated if user-visible behavior changes.

The documentation does not need to be updated as this fixes an expected behaviour.

## Breaking Changes

None, the templates render without them already.

## Testing Notes

Add affinity and/or nodeSelector according to the existing documentation and deployment will show it will be applied. 

kubectl -n slinky get deployment.apps/slurm-bridge-admission -o yaml

```
  template:
    metadata:
      labels:
        app.kubernetes.io/component: admission
        app.kubernetes.io/instance: teszt
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/name: slurm-bridge-admission
        app.kubernetes.io/version: "25.11"
        helm.sh/chart: slurm-bridge-1.2.0-rc1
    spec:
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: node-role.kubernetes.io/control-plane
                operator: Exists
```

## Additional Context

Multi-node kubernetes deployment.
