### PR TITLE
fix: config changes should take effect on helm upgrade

### DIFF
--- a/helm/slurm-bridge/templates/admission/deployment.yaml
+++ b/helm/slurm-bridge/templates/admission/deployment.yaml
@@ -20,6 +20,8 @@ spec:
     metadata:
       labels:
         {{- include "slurm-bridge.admission.labels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       {{- with .Values.admission.priorityClassName }}
       priorityClassName: {{ . }}

--- a/helm/slurm-bridge/templates/controllers/deployment.yaml
+++ b/helm/slurm-bridge/templates/controllers/deployment.yaml
@@ -19,6 +19,8 @@ spec:
     metadata:
       labels:
         {{- include "slurm-bridge.controllers.labels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       {{- with .Values.controllers.priorityClassName }}
       priorityClassName: {{ . }}

--- a/helm/slurm-bridge/templates/scheduler/deployment.yaml
+++ b/helm/slurm-bridge/templates/scheduler/deployment.yaml
@@ -19,6 +19,9 @@ spec:
     metadata:
       labels:
         {{- include "slurm-bridge.scheduler.labels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/scheduler-config: {{ include (print $.Template.BasePath "/scheduler/configmap.yaml") . | sha256sum }}
     spec:
       {{- with .Values.scheduler.priorityClassName }}
       priorityClassName: {{ . }}

--- a/helm/slurm-bridge/tests/__snapshot__/admission_test.yaml.snap
+++ b/helm/slurm-bridge/tests/__snapshot__/admission_test.yaml.snap
@@ -20,6 +20,8 @@ manifests should match snapshot:
           app.kubernetes.io/name: slurm-bridge-admission
       template:
         metadata:
+          annotations:
+            checksum/config: e52364aa50203cb6d54d245f9245986ec8c42fb8d70382ecdac7012ab7cd2b63
           labels:
             app.kubernetes.io/component: admission
             app.kubernetes.io/instance: test-release
@@ -233,3 +235,21 @@ manifests should match snapshot:
               - pods
             scope: Namespaced
         sideEffects: None
+  8: |
+    apiVersion: v1
+    data:
+      config.yaml: |
+        schedulerName: slurm-bridge-scheduler
+        slurmRestApi: http://slurm-restapi.slurm:6820
+        managedNamespaces:
+          - slurm-bridge
+        mcsLabel: kubernetes
+        partition: slurm-bridge
+    kind: ConfigMap
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-bridge-1.2.3
+      name: slurm-bridge-config
+      namespace: test-namespace

--- a/helm/slurm-bridge/tests/__snapshot__/controllers_test.yaml.snap
+++ b/helm/slurm-bridge/tests/__snapshot__/controllers_test.yaml.snap
@@ -1,5 +1,23 @@
 manifests should match snapshot:
   1: |
+    apiVersion: v1
+    data:
+      config.yaml: |
+        schedulerName: slurm-bridge-scheduler
+        slurmRestApi: http://slurm-restapi.slurm:6820
+        managedNamespaces:
+          - slurm-bridge
+        mcsLabel: kubernetes
+        partition: slurm-bridge
+    kind: ConfigMap
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-bridge-1.2.3
+      name: slurm-bridge-config
+      namespace: test-namespace
+  2: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -20,6 +38,8 @@ manifests should match snapshot:
           app.kubernetes.io/name: slurm-bridge-controllers
       template:
         metadata:
+          annotations:
+            checksum/config: e52364aa50203cb6d54d245f9245986ec8c42fb8d70382ecdac7012ab7cd2b63
           labels:
             app.kubernetes.io/component: controllers
             app.kubernetes.io/instance: test-release
@@ -59,7 +79,7 @@ manifests should match snapshot:
             - configMap:
                 name: slurm-bridge-config
               name: slurm-bridge-config
-  2: |
+  3: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
@@ -72,7 +92,7 @@ manifests should match snapshot:
         helm.sh/chart: slurm-bridge-1.2.3
       name: slurm-bridge-controllers
       namespace: test-namespace
-  3: |
+  4: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -118,7 +138,7 @@ manifests should match snapshot:
           - get
           - list
           - watch
-  4: |
+  5: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -138,7 +158,7 @@ manifests should match snapshot:
       - kind: ServiceAccount
         name: slurm-bridge-controllers
         namespace: test-namespace
-  5: |
+  6: |
     apiVersion: v1
     kind: Service
     metadata:

--- a/helm/slurm-bridge/tests/__snapshot__/scheduler_test.yaml.snap
+++ b/helm/slurm-bridge/tests/__snapshot__/scheduler_test.yaml.snap
@@ -2,6 +2,24 @@ manifests should match snapshot:
   1: |
     apiVersion: v1
     data:
+      config.yaml: |
+        schedulerName: slurm-bridge-scheduler
+        slurmRestApi: http://slurm-restapi.slurm:6820
+        managedNamespaces:
+          - slurm-bridge
+        mcsLabel: kubernetes
+        partition: slurm-bridge
+    kind: ConfigMap
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/version: 1.2.3
+        helm.sh/chart: slurm-bridge-1.2.3
+      name: slurm-bridge-config
+      namespace: test-namespace
+  2: |
+    apiVersion: v1
+    data:
       scheduler-config.yaml: |
         apiVersion: kubescheduler.config.k8s.io/v1
         kind: KubeSchedulerConfiguration
@@ -51,7 +69,7 @@ manifests should match snapshot:
     metadata:
       name: scheduler-config
       namespace: test-namespace
-  2: |
+  3: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -72,6 +90,9 @@ manifests should match snapshot:
           app.kubernetes.io/name: slurm-bridge-scheduler
       template:
         metadata:
+          annotations:
+            checksum/config: e52364aa50203cb6d54d245f9245986ec8c42fb8d70382ecdac7012ab7cd2b63
+            checksum/scheduler-config: cbda1f53c1cc2426d84a29c3f231b3c1b2d409828da5a52364e0a42c388be285
           labels:
             app.kubernetes.io/component: scheduler
             app.kubernetes.io/instance: test-release
@@ -123,7 +144,7 @@ manifests should match snapshot:
             - configMap:
                 name: slurm-bridge-config
               name: slurm-bridge-config
-  3: |
+  4: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -327,7 +348,7 @@ manifests should match snapshot:
           - get
           - list
           - watch
-  4: |
+  5: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -340,7 +361,7 @@ manifests should match snapshot:
       - kind: ServiceAccount
         name: slurm-bridge-scheduler
         namespace: test-namespace
-  5: |
+  6: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -354,7 +375,7 @@ manifests should match snapshot:
       - kind: ServiceAccount
         name: slurm-bridge-scheduler
         namespace: test-namespace
-  6: |
+  7: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:

--- a/helm/slurm-bridge/tests/admission_test.yaml
+++ b/helm/slurm-bridge/tests/admission_test.yaml
@@ -7,6 +7,7 @@ templates:
   - admission/rbac.yaml
   - admission/service.yaml
   - admission/webhook.yaml
+  - configmap.yaml
 release:
   name: test-release
   namespace: test-namespace
@@ -20,3 +21,14 @@ tests:
         enabled: true
     asserts:
       - matchSnapshot: {}
+  - it: deployment carries a config checksum annotation so configmap changes trigger a rolling restart
+    template: admission/deployment.yaml
+    set:
+      admission:
+        enabled: true
+    asserts:
+      - isNotNullOrEmpty:
+          path: spec.template.metadata.annotations["checksum/config"]
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: ^[0-9a-f]{64}$

--- a/helm/slurm-bridge/tests/controllers_test.yaml
+++ b/helm/slurm-bridge/tests/controllers_test.yaml
@@ -6,6 +6,7 @@ templates:
   - controllers/deployment.yaml
   - controllers/rbac.yaml
   - controllers/service.yaml
+  - configmap.yaml
 release:
   name: test-release
   namespace: test-namespace
@@ -16,3 +17,11 @@ tests:
   - it: manifests should match snapshot
     asserts:
       - matchSnapshot: {}
+  - it: deployment carries a config checksum annotation so configmap changes trigger a rolling restart
+    template: controllers/deployment.yaml
+    asserts:
+      - isNotNullOrEmpty:
+          path: spec.template.metadata.annotations["checksum/config"]
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: ^[0-9a-f]{64}$

--- a/helm/slurm-bridge/tests/scheduler_test.yaml
+++ b/helm/slurm-bridge/tests/scheduler_test.yaml
@@ -7,6 +7,7 @@ templates:
   - scheduler/configmap.yaml
   - scheduler/rbac.yaml
   - scheduler/serviceaccount.yaml
+  - configmap.yaml
 release:
   name: test-release
   namespace: test-namespace
@@ -17,3 +18,16 @@ tests:
   - it: manifests should match snapshot
     asserts:
       - matchSnapshot: {}
+  - it: deployment carries config checksum annotations so configmap changes trigger a rolling restart
+    template: scheduler/deployment.yaml
+    asserts:
+      - isNotNullOrEmpty:
+          path: spec.template.metadata.annotations["checksum/config"]
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: ^[0-9a-f]{64}$
+      - isNotNullOrEmpty:
+          path: spec.template.metadata.annotations["checksum/scheduler-config"]
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/scheduler-config"]
+          pattern: ^[0-9a-f]{64}$


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->

<!--
Feature requests, code contributions, and bug reports are welcome!
GitHub issues and pull requests are handled on a best-effort basis.
The SchedMD official issue tracker is at <https://support.schedmd.com/>.
-->

## Summary

Resolves https://github.com/SlinkyProject/slurm-bridge/issues/30

This adds the [canonical Helm `checksum/config` annotation](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments) on the pod template of each deployment, plus `checksum/scheduler-config` on the scheduler, in order to have helm upgrades correctly apply configuration to the service in live releases.

## Checklist

- [x] I have read
  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-bridge/blob/main/CONTRIBUTING.md)
  and the
  [Code of Conduct](https://github.com/SlinkyProject/slurm-bridge/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [ ] Documentation is updated if user-visible behavior changes.

## Breaking Changes

None. The first `helm upgrade` after this PR ships will perform a one-time rolling restart of all three Deployments (the annotation appears on the Pod template for the first time). Subsequent no-op upgrades do not restart pods.

## Testing Notes

- `make helm-unittest`
- `make helm-lint` 
- Manual tests in live cluster
