### PR TITLE
Fix - Improve error when Slurm GRES allocation has no index for DRA selector

### DIFF
--- a/internal/nodeinfo/nodeinfo.go
+++ b/internal/nodeinfo/nodeinfo.go
@@ -65,6 +65,9 @@ func (n *NodeInfo) GetDeviceRequests(ctx context.Context, kubeclient client.Clie
 		if !hasDeviceClass(ctx, kubeclient, gres.Type) {
 			continue
 		}
+		if strings.TrimSpace(gres.Index) == "" {
+			return nil, fmt.Errorf("cannot build DRA CEL selector: missing GRES index for %s:%s", gres.Name, gres.Type)
+		}
 		indexList, err := hostlist.Expand(fmt.Sprintf("[%s]", gres.Index))
 		if err != nil {
 			return nil, err
@@ -139,6 +142,9 @@ func (n *NodeInfo) GetDeviceRequestAllocationResult(ctx context.Context, kubecli
 		deviceClassName := gres.Type
 		if !hasDeviceClass(ctx, kubeclient, gres.Type) {
 			continue
+		}
+		if strings.TrimSpace(gres.Index) == "" {
+			return nil, fmt.Errorf("cannot build DRA CEL selector: missing GRES index for %s:%s", gres.Name, gres.Type)
 		}
 		indexList, err := hostlist.Expand(fmt.Sprintf("[%s]", gres.Index))
 		if err != nil {

--- a/internal/nodeinfo/nodeinfo_test.go
+++ b/internal/nodeinfo/nodeinfo_test.go
@@ -47,6 +47,7 @@ func TestNodeInfo_GetDeviceRequests(t *testing.T) {
 		resources  *slurmcontrol.NodeResources
 		want       []resourcev1.DeviceRequest
 		wantErr    bool
+		wantErrMsg string
 	}{
 		{
 			name: "dra.cpu",
@@ -204,6 +205,29 @@ func TestNodeInfo_GetDeviceRequests(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name: "gpu.example.com missing gres index",
+			kubeclient: fake.NewClientBuilder().
+				WithObjects(
+					&resourcev1.DeviceClass{
+						ObjectMeta: metav1.ObjectMeta{Name: nodeinfo.DraExampleDriver},
+					},
+				).
+				Build(),
+			nodeName: "node",
+			resources: &slurmcontrol.NodeResources{
+				Node: "node",
+				Gres: []slurmcontrol.GresLayout{
+					{
+						Name:  "gpu",
+						Type:  nodeinfo.DraExampleDriver,
+						Count: 1,
+					},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "cannot build DRA CEL selector: missing GRES index for gpu:gpu.example.com",
 		},
 		{
 			name: "gpu.nvidia.com",
@@ -388,6 +412,9 @@ func TestNodeInfo_GetDeviceRequests(t *testing.T) {
 				if !tt.wantErr {
 					t.Errorf("GetDeviceRequests() failed: %v", gotErr)
 				}
+				if tt.wantErrMsg != "" && gotErr.Error() != tt.wantErrMsg {
+					t.Errorf("GetDeviceRequests() error = %q, want %q", gotErr.Error(), tt.wantErrMsg)
+				}
 				return
 			}
 			if tt.wantErr {
@@ -408,6 +435,7 @@ func TestNodeInfo_GetDeviceRequestAllocationResult(t *testing.T) {
 		resources  *slurmcontrol.NodeResources
 		want       []resourcev1.DeviceRequestAllocationResult
 		wantErr    bool
+		wantErrMsg string
 	}{
 		{
 			name: "dra.cpu",
@@ -541,6 +569,29 @@ func TestNodeInfo_GetDeviceRequestAllocationResult(t *testing.T) {
 			},
 		},
 		{
+			name: "gpu.example.com missing gres index",
+			kubeclient: fake.NewClientBuilder().
+				WithObjects(
+					&resourcev1.DeviceClass{
+						ObjectMeta: metav1.ObjectMeta{Name: nodeinfo.DraExampleDriver},
+					},
+				).
+				Build(),
+			nodeName: "node",
+			resources: &slurmcontrol.NodeResources{
+				Node: "node",
+				Gres: []slurmcontrol.GresLayout{
+					{
+						Name:  "gpu",
+						Type:  nodeinfo.DraExampleDriver,
+						Count: 1,
+					},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "cannot build DRA CEL selector: missing GRES index for gpu:gpu.example.com",
+		},
+		{
 			name: "gpu.nvidia.com",
 			kubeclient: fake.NewClientBuilder().
 				WithIndex(&resourcev1.ResourceSlice{}, "spec.nodeName", resourceSliceNodeIndex).
@@ -593,6 +644,9 @@ func TestNodeInfo_GetDeviceRequestAllocationResult(t *testing.T) {
 			if gotErr != nil {
 				if !tt.wantErr {
 					t.Errorf("GetDeviceRequestAllocationResult() failed: %v", gotErr)
+				}
+				if tt.wantErrMsg != "" && gotErr.Error() != tt.wantErrMsg {
+					t.Errorf("GetDeviceRequestAllocationResult() error = %q, want %q", gotErr.Error(), tt.wantErrMsg)
 				}
 				return
 			}


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->

<!--
Feature requests, code contributions, and bug reports are welcome!
GitHub issues and pull requests are handled on a best-effort basis.
The SchedMD official issue tracker is at <https://support.schedmd.com/>.
-->

## Summary

<!--
Describe what this is for and why it is needed.
Link relevant issues which this addresses (e.g. closes #123).
-->

Improves validation for DRA-backed Slurm GRES allocations when Slurm REST returns a GRES entry without an `index`.

Previously, Slurm Bridge when building a DRA CEL selector from an empty GRES index fails with a misleading scheduler error:

```text
running PreBind plugin "SlurmBridge": expression cannot be empty string
```

This change returns an actionable error earlier instead:
```text
cannot build DRA CEL selector: missing GRES index for gpu:gpu.example.com
```

Closes #33.

## Checklist

- [x] I have read
  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-bridge/blob/main/CONTRIBUTING.md)
  and the
  [Code of Conduct](https://github.com/SlinkyProject/slurm-bridge/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes.

## Breaking Changes

<!--
Does this cause any breaking changes to users?
Explain why the breakage has to happen.
-->

None

## Testing Notes

<!--
How to test this change.
-->

```bash
go test ./internal/nodeinfo
```

## Additional Context

<!--
Any other context for reviewers.
-->

None