### PR TITLE
fix(controllers): reconcile not-Ready pods against their placeholder job

### DIFF
--- a/internal/controller/pod/pod_sync.go
+++ b/internal/controller/pod/pod_sync.go
@@ -60,13 +60,18 @@ func (r *PodReconciler) syncKubernetes(ctx context.Context, req reconcile.Reques
 		return nil
 	}
 
-	// Requeue Pod request until terminal
-	if !podv1.IsPodTerminal(pod) {
-		durationStore.Push(podKey, 30*time.Second)
+	// Terminal pods are handled by prepareTerminalPod
+	if podv1.IsPodTerminal(pod) {
+		logger.V(2).Info("Pod is terminal, skipping", "pod", klog.KObj(pod))
+		return nil
 	}
 
-	if pod.Status.Phase != corev1.PodRunning || !podv1.IsPodReady(pod) {
-		logger.V(2).Info("Pod is not running, skipping", "pod", klog.KObj(pod))
+	// Requeue Pod request until terminal
+	durationStore.Push(podKey, 30*time.Second)
+
+	// Unbound pods must be scheduled before checking if the Slurm job is running
+	if pod.Spec.NodeName == "" {
+		logger.V(2).Info("Pod is not bound, skipping", "pod", klog.KObj(pod))
 		return nil
 	}
 

--- a/internal/controller/pod/pod_sync_test.go
+++ b/internal/controller/pod/pod_sync_test.go
@@ -52,6 +52,7 @@ func newPod(name string, jobId int32) *corev1.Pod {
 		},
 		Spec: corev1.PodSpec{
 			SchedulerName: schedulerName,
+			NodeName:      "test-node",
 		},
 		Status: corev1.PodStatus{
 			Phase: corev1.PodRunning,
@@ -64,6 +65,30 @@ func newPod(name string, jobId int32) *corev1.Pod {
 			},
 		},
 	}
+}
+
+// newQueuedPod returns a pod that has not been bound yet (awaiting
+// placement).
+func newQueuedPod(name string, jobId int32) *corev1.Pod {
+	pod := newPod(name, jobId)
+	pod.Spec.NodeName = ""
+	pod.Status.Phase = corev1.PodPending
+	pod.Status.Conditions = nil
+	return pod
+}
+
+// newNotReadyPod returns a pod bound to a Slurm job that is Running but not
+// Ready (e.g. crash-looping).
+func newNotReadyPod(name string, jobId int32) *corev1.Pod {
+	pod := newPod(name, jobId)
+	pod.Status.Conditions = []corev1.PodCondition{
+		{
+			Type:               corev1.PodReady,
+			LastTransitionTime: metav1.Now(),
+			Status:             corev1.ConditionFalse,
+		},
+	}
+	return pod
 }
 
 func newTerminatingPod(name string, jobId int32) *corev1.Pod {
@@ -112,6 +137,40 @@ var _ = Describe("syncKubernetes()", func() {
 						AdminComment: ptr.To(newExternalJobInfo("bar").ToString()),
 					},
 				},
+				{
+					V0044JobInfo: api.V0044JobInfo{
+						JobId:        ptr.To[int32](3),
+						JobState:     &[]api.V0044JobInfoJobState{api.V0044JobInfoJobStateRUNNING},
+						AdminComment: ptr.To(newExternalJobInfo("crashloop").ToString()),
+					},
+				},
+				{
+					V0044JobInfo: api.V0044JobInfo{
+						JobId: ptr.To[int32](4),
+						JobState: &[]api.V0044JobInfoJobState{
+							api.V0044JobInfoJobStatePENDING,
+							api.V0044JobInfoJobStatePREEMPTED,
+						},
+						AdminComment: ptr.To(newExternalJobInfo("requeued").ToString()),
+					},
+				},
+				{
+					V0044JobInfo: api.V0044JobInfo{
+						JobId: ptr.To[int32](5),
+						JobState: &[]api.V0044JobInfoJobState{
+							api.V0044JobInfoJobStatePENDING,
+							api.V0044JobInfoJobStatePREEMPTED,
+						},
+						AdminComment: ptr.To(newExternalJobInfo("requeued-bound").ToString()),
+					},
+				},
+				{
+					V0044JobInfo: api.V0044JobInfo{
+						JobId:        ptr.To[int32](6),
+						JobState:     &[]api.V0044JobInfoJobState{api.V0044JobInfoJobStateSUSPENDED},
+						AdminComment: ptr.To(newExternalJobInfo("suspended").ToString()),
+					},
+				},
 			},
 		}
 		c := slurmclientfake.NewClientBuilder().WithLists(jobList).Build()
@@ -119,6 +178,12 @@ var _ = Describe("syncKubernetes()", func() {
 			Items: []corev1.Pod{
 				*newPod(podName, jobId),
 				*newPod("bar", 0),
+				*newQueuedPod("unlabeled-queued", 0),
+				*newNotReadyPod("crashloop", 3),
+				*newQueuedPod("queued", 4),
+				*newNotReadyPod("requeued-bound", 5),
+				*newPod("suspended", 6),
+				*newQueuedPod("queued-dead", 7),
 			},
 		}
 		controller = &PodReconciler{
@@ -156,6 +221,118 @@ var _ = Describe("syncKubernetes()", func() {
 
 			By("Check pod existence")
 			key := types.NamespacedName{Namespace: corev1.NamespaceDefault, Name: podName}
+			pod := &corev1.Pod{}
+			err = controller.Get(ctx, key, pod)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
+	Context("With a not-Ready (crash-looping) pod", func() {
+		// Regression: a crash-looping pod is never Ready, but its Slurm job
+		// can still be preempted/cancelled. It must be deleted like any
+		// other pod, or its ResourceClaim keeps a device allocation that
+		// Slurm has already handed to another pod (device double-booking).
+		It("Should terminate the pod when its job is gone", func() {
+			By("Terminating the corresponding Slurm job")
+			err := controller.slurmControl.TerminateJob(ctx, 3)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Reconciling")
+			err = controller.syncKubernetes(ctx, newRequest("crashloop"))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Check pod existence")
+			key := types.NamespacedName{Namespace: corev1.NamespaceDefault, Name: "crashloop"}
+			pod := &corev1.Pod{}
+			err = controller.Get(ctx, key, pod)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("Should not terminate the pod while its job is running", func() {
+			By("Reconciling")
+			err := controller.syncKubernetes(ctx, newRequest("crashloop"))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Check pod existence")
+			key := types.NamespacedName{Namespace: corev1.NamespaceDefault, Name: "crashloop"}
+			pod := &corev1.Pod{}
+			err = controller.Get(ctx, key, pod)
+			Expect(apierrors.IsNotFound(err)).ToNot(BeTrue())
+		})
+
+		It("Should terminate a bound pod whose job was requeued (stale binding)", func() {
+			By("Reconciling")
+			err := controller.syncKubernetes(ctx, newRequest("requeued-bound"))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Check pod existence")
+			key := types.NamespacedName{Namespace: corev1.NamespaceDefault, Name: "requeued-bound"}
+			pod := &corev1.Pod{}
+			err = controller.Get(ctx, key, pod)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("Should terminate a pod whose job is suspended", func() {
+			By("Reconciling")
+			err := controller.syncKubernetes(ctx, newRequest("suspended"))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Check pod existence")
+			key := types.NamespacedName{Namespace: corev1.NamespaceDefault, Name: "suspended"}
+			pod := &corev1.Pod{}
+			err = controller.Get(ctx, key, pod)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
+	Context("With unbound pods", func() {
+		// Unbound pods are owned by the scheduler and never reconciled,
+		// whatever the state of their job (or lack of one).
+		It("Should not terminate a queued pod while its job is pending", func() {
+			By("Reconciling")
+			err := controller.syncKubernetes(ctx, newRequest("queued"))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Check pod existence")
+			key := types.NamespacedName{Namespace: corev1.NamespaceDefault, Name: "queued"}
+			pod := &corev1.Pod{}
+			err = controller.Get(ctx, key, pod)
+			Expect(apierrors.IsNotFound(err)).ToNot(BeTrue())
+		})
+
+		It("Should not terminate a queued pod whose job is gone", func() {
+			By("Reconciling")
+			err := controller.syncKubernetes(ctx, newRequest("queued-dead"))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Check pod existence")
+			key := types.NamespacedName{Namespace: corev1.NamespaceDefault, Name: "queued-dead"}
+			pod := &corev1.Pod{}
+			err = controller.Get(ctx, key, pod)
+			Expect(apierrors.IsNotFound(err)).ToNot(BeTrue())
+		})
+
+		It("Should not terminate an unlabeled queued pod", func() {
+			By("Reconciling")
+			err := controller.syncKubernetes(ctx, newRequest("unlabeled-queued"))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Check pod existence")
+			key := types.NamespacedName{Namespace: corev1.NamespaceDefault, Name: "unlabeled-queued"}
+			pod := &corev1.Pod{}
+			err = controller.Get(ctx, key, pod)
+			Expect(apierrors.IsNotFound(err)).ToNot(BeTrue())
+		})
+	})
+
+	Context("With a bound pod not labeled with a Slurm job", func() {
+		It("Should terminate the pod (orphan without a job)", func() {
+			By("Reconciling the orphan pod")
+			err := controller.syncKubernetes(ctx, newRequest("bar"))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Check pod existence")
+			key := types.NamespacedName{Namespace: corev1.NamespaceDefault, Name: "bar"}
 			pod := &corev1.Pod{}
 			err = controller.Get(ctx, key, pod)
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->

<!--
Feature requests, code contributions, and bug reports are welcome!
GitHub issues and pull requests are handled on a best-effort basis.
The SchedMD official issue tracker is at <https://support.schedmd.com/>.
-->

## Summary

Closes #36.

The pod controller only reconciles a pod against its Slurm placeholder job while the pod is `Running` **and** `Ready`. A pod that never becomes Ready (crash-looping container, stuck in Init, failing readiness probe) is skipped on every reconcile. When Slurm preempts or cancels its placeholder job, the pod persists indefinitely. On DRA clusters the stale pod retains its `ResourceClaim` device allocation while Slurm reissues the freed GRES to the next job; the scheduler then stamps a second claim for the same device and the successor pod wedges in `Init` on `NodePrepareResources` ("requested device is already allocated to different claim"), requiring manual intervention.

This PR gates reconciliation on **binding** instead of readiness: A bound pod may exist only if its placeholder job is `RUNNING`. This is sound because the scheduler only binds a pod after its job starts, so post-bind, `RUNNING` is the only healthy job state.

## Checklist

- [x] I have read
  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-bridge/blob/main/CONTRIBUTING.md)
  and the
  [Code of Conduct](https://github.com/SlinkyProject/slurm-bridge/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes.

## Breaking Changes

No API changes. Exactly one behavioral delta: **bound pods that are not Ready are now reconciled** — a crash-looping (or still-starting) pod whose placeholder job stops running is deleted instead of leaking forever. This is the fix. Bound Ready pods, unbound pods, and unlabeled pods have no behavior changes.

## Testing Notes

- Unit: `go test ./internal/controller/...` — ginkgo cases covering every combination: crash-looping (job running vs job gone), queued (job pending, job gone, unlabeled), bound-requeued, suspended, and bound-unlabeled orphan pods.
- e2e on kind (`hack/kind.sh --core`): bridge-scheduled crash-looping pod (never Ready) + healthy control pod; `scancel` the crash-looper's placeholder job, results in pod deletion within one 30s reconcile (`Deleting Pod for corresponding Slurm Job`), claim released, healthy pod untouched.

