### PR TITLE
Fix - Truncate feasible node list to match pod count in PostFilter

### DIFF
--- a/internal/scheduler/plugins/slurmbridge/slurmbridge.go
+++ b/internal/scheduler/plugins/slurmbridge/slurmbridge.go
@@ -412,6 +412,10 @@ func (sb *SlurmBridge) PostFilter(ctx context.Context, state fwk.CycleState, pod
 		}
 	}
 
+	if len(s.slurmJobIR.JobInfo.Nodes) > len(s.slurmJobIR.Pods.Items) {
+		s.slurmJobIR.JobInfo.Nodes = s.slurmJobIR.JobInfo.Nodes[:len(s.slurmJobIR.Pods.Items)]
+	}
+
 	// If this situation occurs, the best we can do is trigger another
 	// scheduling cycle.
 	if len(s.slurmJobIR.JobInfo.Nodes) < len(s.slurmJobIR.Pods.Items) {


### PR DESCRIPTION
## Summary

PostFilter appends every node that passes the Filter plugins to
`JobInfo.Nodes`, uncapped. That list becomes `RequiredNodes` in the job
submission — SLURM's "must include all of these" constraint, not a
candidate pool. `MaxNodes` is set independently, always equal to the
job's pod count.

Whenever more nodes pass Filter than the job has pods, `RequiredNodes`
ends up longer than `MaxNodes` — an unsatisfiable combination. Shows up
as either a 422 on submit, or a job accepted and then stuck PENDING with
`Reason=Resources`.

Truncates the feasible-node list to the pod count right after building
it, so `RequiredNodes` can never exceed `MaxNodes`.

## Checklist

- [x] I have read
  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-bridge/blob/main/CONTRIBUTING.md)
  and the
  [Code of Conduct](https://github.com/SlinkyProject/slurm-bridge/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes.

## Breaking Changes

None.

## Testing Notes

```bash
go test ./internal/scheduler/plugins/slurmbridge/...
```

Also reproduced and fixed live: a JobSet with more schedulable nodes than
pods went from permanently PENDING to scheduling correctly.

## Additional Context

No existing issue tracks this.