### PR TITLE
fix(scheduler): submit excluded_nodes instead of required_nodes

### DIFF
--- a/internal/scheduler/plugins/slurmbridge/slurmbridge.go
+++ b/internal/scheduler/plugins/slurmbridge/slurmbridge.go
@@ -418,6 +418,32 @@ func (sb *SlurmBridge) PostFilter(ctx context.Context, state fwk.CycleState, pod
 		return nil, fwk.NewStatus(fwk.Success)
 	}
 
+	// Slurm nodes that kubernetes cannot place this pod on — cordoned,
+	// tainted, failing affinity, or without free resources (rejected by
+	// any Filter plugin other than SlurmBridge) — are passed to Slurm as
+	// excluded nodes. Exclusion is used instead of required_nodes because
+	// required_nodes is fatally re-validated at slurmctld state recovery:
+	// one entry naming a since-deleted node kills the job, while stale
+	// excluded_nodes entries are tolerated.
+	allNodes, err := sb.handle.SnapshotSharedLister().NodeInfos().List()
+	if err != nil {
+		logger.Error(err, "error listing all nodes from the snapshot")
+		return nil, fwk.NewStatus(fwk.Error, err.Error())
+	}
+	feasibleSet := sets.New(s.slurmJobIR.JobInfo.Nodes...)
+	for _, node := range allNodes {
+		if node.Node() == nil {
+			continue
+		}
+		slurmName := nodecontrollerutils.GetSlurmNodeName(node.Node())
+		if feasibleSet.Has(slurmName) {
+			continue
+		}
+		if slurmNodes.Has(slurmName) {
+			s.slurmJobIR.JobInfo.ExcNodes = append(s.slurmJobIR.JobInfo.ExcNodes, slurmName)
+		}
+	}
+
 	// If no external job exists, we should create one with the list
 	// of nodes that passed Filter plugins.
 	if externalJob.JobId == 0 {

--- a/internal/scheduler/plugins/slurmbridge/slurmbridge_test.go
+++ b/internal/scheduler/plugins/slurmbridge/slurmbridge_test.go
@@ -964,6 +964,59 @@ func TestSlurmBridge_PostFilter(t *testing.T) {
 			wantActivate: true,
 		},
 		{
+			name: "Nodes filtered by other plugins are submitted as excluded nodes",
+			fields: fields{
+				Client: kubefake.NewFakeClient(
+					pod.DeepCopy(),
+					&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+					&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2"}},
+				),
+				slurmControl: func() slurmcontrol.SlurmControlInterface {
+					f := interceptor.Funcs{
+						Create: func(ctx context.Context, obj object.Object, req any, opts ...slurmclient.CreateOption) error {
+							jobSubmit := req.(api.V0044JobSubmitReq)
+							if jobSubmit.Job.RequiredNodes != nil {
+								return fmt.Errorf("expected RequiredNodes to be unset, got %v", *jobSubmit.Job.RequiredNodes)
+							}
+							if jobSubmit.Job.ExcludedNodes == nil || !reflect.DeepEqual(*jobSubmit.Job.ExcludedNodes, api.V0044CsvString{"node2"}) {
+								return fmt.Errorf("expected ExcludedNodes [node2], got %v", jobSubmit.Job.ExcludedNodes)
+							}
+							obj.(*types.V0044JobInfo).JobId = ptr.To(int32(1))
+							return nil
+						},
+					}
+					nodes := &types.V0044NodeList{
+						Items: []types.V0044Node{
+							{V0044Node: api.V0044Node{Name: ptr.To("node1")}},
+							{V0044Node: api.V0044Node{Name: ptr.To("node2")}},
+						},
+					}
+					c := fake.NewClientBuilder().
+						WithInterceptorFuncs(f).
+						WithLists(nodes).
+						Build()
+					return slurmcontrol.NewControl(c, "kubernetes", "slurm-bridge")
+				}(),
+				handle: f,
+			},
+			args: args{
+				ctx:   ctx,
+				state: framework.NewCycleState(),
+				pod:   pod.DeepCopy(),
+				m: framework.NewNodeToStatus(map[string]*fwk.Status{
+					// node1 was rejected only by SlurmBridge itself: it is
+					// kubernetes-feasible and stays out of the exclusion.
+					"node1": fwk.NewStatus(fwk.Unschedulable).WithPlugin(Name),
+					// node2 was rejected by another Filter plugin: it must
+					// be handed to Slurm as an excluded node.
+					"node2": fwk.NewStatus(fwk.Unschedulable).WithPlugin("NodeResourcesFit"),
+				}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
+			},
+			want:         nil,
+			want1:        fwk.NewStatus(fwk.Success),
+			wantActivate: true,
+		},
+		{
 			name: "Updating an external job succeeds",
 			fields: fields{
 				Client: kubefake.NewFakeClient(

--- a/internal/scheduler/plugins/slurmbridge/slurmcontrol/slurmcontrol.go
+++ b/internal/scheduler/plugins/slurmbridge/slurmcontrol/slurmcontrol.go
@@ -192,10 +192,17 @@ func (r *realSlurmControl) submitJob(ctx context.Context, pod *corev1.Pod, slurm
 					return &api.V0044Uint64NoValStruct{Set: ptr.To(false)}
 				}
 			}(),
-			MinimumNodes:  slurmJobIR.JobInfo.MinNodes,
-			Name:          slurmJobIR.JobInfo.JobName,
-			Nodes:         ptr.To(strconv.Itoa(len(slurmJobIR.Pods.Items))),
-			RequiredNodes: ptr.To(api.V0044CsvString(slurmJobIR.JobInfo.Nodes)),
+			MinimumNodes: slurmJobIR.JobInfo.MinNodes,
+			Name:         slurmJobIR.JobInfo.JobName,
+			Nodes:        ptr.To(strconv.Itoa(len(slurmJobIR.Pods.Items))),
+			// Use excluded_nodes, not required_nodes, to pass kubernetes constraints to Slurm.
+			// Stale required_nodes kill jobs at slurmctld state recovery (present through Slurm 26.05.3).
+			ExcludedNodes: func() *api.V0044CsvString {
+				if len(slurmJobIR.JobInfo.ExcNodes) == 0 {
+					return nil
+				}
+				return ptr.To(api.V0044CsvString(slurmJobIR.JobInfo.ExcNodes))
+			}(),
 			Priority: func() *api.V0044Uint32NoValStruct {
 				if slurmJobIR.JobInfo.Priority != nil {
 					return &api.V0044Uint32NoValStruct{

--- a/internal/scheduler/plugins/slurmbridge/slurmcontrol/slurmcontrol_test.go
+++ b/internal/scheduler/plugins/slurmbridge/slurmcontrol/slurmcontrol_test.go
@@ -616,6 +616,74 @@ func Test_realSlurmControl_SubmitJob(t *testing.T) {
 			want:    1,
 			wantErr: false,
 		},
+		{
+			name: "Submit external job passes infeasible nodes as ExcludedNodes and never RequiredNodes",
+			fields: fields{
+				Client: func() client.Client {
+					f := interceptor.Funcs{
+						Create: func(ctx context.Context, obj object.Object, req any, opts ...client.CreateOption) error {
+							obj.(*slurmtypes.V0044JobInfo).JobId = ptr.To(int32(1))
+							jobSubmit := req.(api.V0044JobSubmitReq)
+							if jobSubmit.Job.RequiredNodes != nil {
+								return fmt.Errorf("expected RequiredNodes to be unset, got %v", *jobSubmit.Job.RequiredNodes)
+							}
+							if jobSubmit.Job.ExcludedNodes == nil {
+								return fmt.Errorf("expected ExcludedNodes to be set")
+							}
+							if !reflect.DeepEqual(*jobSubmit.Job.ExcludedNodes, api.V0044CsvString{"node3"}) {
+								return fmt.Errorf("expected ExcludedNodes [node3], got %v", *jobSubmit.Job.ExcludedNodes)
+							}
+							return nil
+						},
+					}
+					return fake.NewClientBuilder().
+						WithInterceptorFuncs(f).
+						Build()
+				}(),
+			},
+			args: args{
+				ctx: context.Background(),
+				pod: st.MakePod().Name("foo").Namespace("slurm-bridge").Obj(),
+				slurmJobIR: &slurmjobir.SlurmJobIR{JobInfo: slurmjobir.SlurmJobIRJobInfo{
+					Nodes:    []string{"node1", "node2"},
+					ExcNodes: []string{"node3"},
+				}},
+			},
+			want:    1,
+			wantErr: false,
+		},
+		{
+			name: "Submit external job omits ExcludedNodes when every node is feasible",
+			fields: fields{
+				Client: func() client.Client {
+					f := interceptor.Funcs{
+						Create: func(ctx context.Context, obj object.Object, req any, opts ...client.CreateOption) error {
+							obj.(*slurmtypes.V0044JobInfo).JobId = ptr.To(int32(1))
+							jobSubmit := req.(api.V0044JobSubmitReq)
+							if jobSubmit.Job.RequiredNodes != nil {
+								return fmt.Errorf("expected RequiredNodes to be unset, got %v", *jobSubmit.Job.RequiredNodes)
+							}
+							if jobSubmit.Job.ExcludedNodes != nil {
+								return fmt.Errorf("expected ExcludedNodes to be unset, got %v", *jobSubmit.Job.ExcludedNodes)
+							}
+							return nil
+						},
+					}
+					return fake.NewClientBuilder().
+						WithInterceptorFuncs(f).
+						Build()
+				}(),
+			},
+			args: args{
+				ctx: context.Background(),
+				pod: st.MakePod().Name("foo").Namespace("slurm-bridge").Obj(),
+				slurmJobIR: &slurmjobir.SlurmJobIR{JobInfo: slurmjobir.SlurmJobIRJobInfo{
+					Nodes: []string{"node1", "node2"},
+				}},
+			},
+			want:    1,
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/utils/slurmjobir/slurmjobir.go
+++ b/internal/utils/slurmjobir/slurmjobir.go
@@ -44,6 +44,7 @@ type SlurmJobIRJobInfo struct {
 	MinNodes     *int32
 	MaxNodes     *int32
 	Nodes        []string
+	ExcNodes     []string
 	Partition    *string
 	Priority     *int32
 	QOS          *string


### PR DESCRIPTION


## Summary

slurmctld fatally re-validates required_nodes on every state recovery (every restart and every reconfigure; present through Slurm 26.05.3): one entry naming a since-deleted node kills the job NODE_FAIL and the pod controller then deletes its healthy pod. Under dynamic nodes, deletion is routine, so any node removal plus any recovery killed every bridge job at once. Submit the kubernetes-rejected nodes as excluded_nodes instead: same placement constraint, but stale entries are tolerated.

## Checklist

- [x] I have read
  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-bridge/blob/main/CONTRIBUTING.md)
  and the
  [Code of Conduct](https://github.com/SlinkyProject/slurm-bridge/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes.

## Breaking Changes

N/A

## Testing Notes

- Tests added
- This has been running for 2 days in our clusters, tested under real load

## Additional Context

<!--
Any other context for reviewers.
-->
