### PR TITLE
perf: stop listing every Slurm job on each scheduling cycle

### DIFF
--- a/internal/runnable/slurmjob/slurmcontrol/slurmcontrol.go
+++ b/internal/runnable/slurmjob/slurmcontrol/slurmcontrol.go
@@ -21,11 +21,25 @@ import (
 	"github.com/SlinkyProject/slurm-bridge/internal/utils/externaljobinfo"
 )
 
+// BridgeJob is a bridge-created external job and the pods it claims via its
+// admin comment.
+type BridgeJob struct {
+	JobId   int32
+	Nodes   string
+	PodKeys []kubetypes.NamespacedName
+}
+
 type SlurmControlInterface interface {
 	// RefreshJobCache forces the Node cache to be refreshed
 	RefreshJobCache(ctx context.Context) error
 	// ListPodsFromJobs returns a list of Slurm jobIds and their pods
 	ListPodsFromJobs(ctx context.Context) ([]int32, []kubetypes.NamespacedName, error)
+	// ListBridgeJobs returns every bridge-created job with its node list and
+	// claimed pods, served from the job cache.
+	ListBridgeJobs(ctx context.Context) ([]BridgeJob, error)
+	// GetJobNodesLive reports whether the job exists in a non-terminal state
+	// and which nodes it holds, bypassing the job cache.
+	GetJobNodesLive(ctx context.Context, jobId int32) (exists bool, nodes string, err error)
 	// GetPodsFromJob returns a list of pod keys associated to the Slurm job.
 	GetPodsFromJob(ctx context.Context, jobId int32) ([]kubetypes.NamespacedName, error)
 	// IsJobPendingOrRunning returns true if the Slurm job with the given jobId is pending or running.
@@ -89,6 +103,52 @@ func (r *realSlurmControl) ListPodsFromJobs(ctx context.Context) ([]int32, []kub
 	}
 
 	return jobIds, pods, nil
+}
+
+// ListBridgeJobs implements SlurmControlInterface.
+func (r *realSlurmControl) ListBridgeJobs(ctx context.Context) ([]BridgeJob, error) {
+	jobList := &types.V0044JobInfoList{}
+	if err := r.List(ctx, jobList); err != nil {
+		return nil, err
+	}
+
+	jobs := []BridgeJob{}
+	for _, job := range jobList.Items {
+		extInfo := &externaljobinfo.ExternalJobInfo{}
+		if err := externaljobinfo.ParseIntoExternalJobInfo(job.AdminComment, extInfo); err != nil {
+			// Assume the job was not created by slurm-bridge
+			continue
+		}
+		out := BridgeJob{
+			JobId: ptr.Deref(job.JobId, 0),
+			Nodes: ptr.Deref(job.Nodes, ""),
+		}
+		for _, podName := range extInfo.Pods {
+			out.PodKeys = append(out.PodKeys, utils.NamespacedNameFromString(podName))
+		}
+		jobs = append(jobs, out)
+	}
+
+	return jobs, nil
+}
+
+// GetJobNodesLive implements SlurmControlInterface.
+func (r *realSlurmControl) GetJobNodesLive(ctx context.Context, jobId int32) (bool, string, error) {
+	if jobId == 0 {
+		return false, "", nil
+	}
+	job := &types.V0044JobInfo{}
+	key := object.ObjectKey(fmt.Sprintf("%d", jobId))
+	if err := r.Get(ctx, key, job, &client.GetOptions{SkipCache: true}); err != nil {
+		if utils.IsSlurmJobNotFoundErr(err) {
+			return false, "", nil
+		}
+		return false, "", err
+	}
+	if job.GetStateAsSet().HasAny(api.V0044JobInfoJobStateCANCELLED, api.V0044JobInfoJobStateCOMPLETED) {
+		return false, "", nil
+	}
+	return true, ptr.Deref(job.Nodes, ""), nil
 }
 
 // GetPodsFromJob implements SlurmControlInterface.

--- a/internal/runnable/slurmjob/slurmjob_pod_metadata.go
+++ b/internal/runnable/slurmjob/slurmjob_pod_metadata.go
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+// SPDX-License-Identifier: Apache-2.0
+
+package slurmjob
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"slices"
+	"strconv"
+
+	"github.com/puttsk/hostlist"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/SlinkyProject/slurm-bridge/internal/runnable/slurmjob/slurmcontrol"
+	"github.com/SlinkyProject/slurm-bridge/internal/utils/slurmjobir"
+	"github.com/SlinkyProject/slurm-bridge/internal/wellknown"
+)
+
+// reconcilePodMetadata will heal pod job-linkage metadata against Slurm.
+// It rewrites a pod's external-job-id label when the labeled job is gone
+// but another bridge job claims the pod, and clears a pod's node annotation
+// when its job does not hold that node.
+func (r *SlurmJobRunnable) reconcilePodMetadata(ctx context.Context) error {
+	jobs, err := r.slurmControl.ListBridgeJobs(ctx)
+	if err != nil {
+		return err
+	}
+
+	errs := []error{}
+	for _, job := range jobs {
+		for _, key := range job.PodKeys {
+			pod := &corev1.Pod{}
+			if err := r.Get(ctx, key, pod); err != nil {
+				if apierrors.IsNotFound(err) {
+					continue
+				}
+				errs = append(errs, err)
+				continue
+			}
+			if err := r.reconcileOnePodMetadata(ctx, pod, job); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (r *SlurmJobRunnable) reconcileOnePodMetadata(ctx context.Context, pod *corev1.Pod, job slurmcontrol.BridgeJob) error {
+	logger := log.FromContext(ctx)
+
+	labelVal := pod.Labels[wellknown.LabelExternalJobId]
+	labeledJobId := slurmjobir.ParseSlurmJobId(labelVal)
+
+	// Prefer the job the pod's label references while it is alive in Slurm;
+	// otherwise the job claiming the pod is authoritative. Confirm with a
+	// live read before correcting.
+	authoritativeId := job.JobId
+	authoritativeNodes := job.Nodes
+	if labelVal != "" && labeledJobId != job.JobId {
+		exists, nodes, err := r.slurmControl.GetJobNodesLive(ctx, labeledJobId)
+		if err != nil {
+			return err
+		}
+		if exists {
+			authoritativeId = labeledJobId
+			authoritativeNodes = nodes
+		}
+	}
+
+	toUpdate := pod.DeepCopy()
+
+	if labelVal != "" && labeledJobId != authoritativeId {
+		logger.Info("Pod jobId label references a job Slurm no longer knows; healing",
+			"pod", client.ObjectKeyFromObject(pod), "label", labelVal, "jobId", authoritativeId)
+		toUpdate.Labels[wellknown.LabelExternalJobId] = strconv.Itoa(int(authoritativeId))
+	}
+
+	// The node annotation only drives scheduling; leave bound pods alone.
+	node := pod.Annotations[wellknown.AnnotationExternalJobNode]
+	if node != "" && pod.Spec.NodeName == "" {
+		exists, liveNodes, err := r.slurmControl.GetJobNodesLive(ctx, authoritativeId)
+		if err != nil {
+			return err
+		}
+		if exists {
+			authoritativeNodes = liveNodes
+		}
+		nodes, _ := hostlist.Expand(authoritativeNodes)
+		if !exists || !slices.Contains(nodes, node) {
+			logger.Info("Pod node annotation names a node its job does not hold; clearing",
+				"pod", client.ObjectKeyFromObject(pod), "node", node)
+			toUpdate.Annotations[wellknown.AnnotationExternalJobNode] = ""
+		}
+	}
+
+	if reflect.DeepEqual(pod, toUpdate) {
+		return nil
+	}
+	return r.Patch(ctx, toUpdate, client.StrategicMergeFrom(pod))
+}

--- a/internal/runnable/slurmjob/slurmjob_pod_metadata_test.go
+++ b/internal/runnable/slurmjob/slurmjob_pod_metadata_test.go
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+// SPDX-License-Identifier: Apache-2.0
+
+package slurmjob
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	slurmapi "github.com/SlinkyProject/slurm-client/api/v0044"
+	slurmclient "github.com/SlinkyProject/slurm-client/pkg/client"
+	slurmclientfake "github.com/SlinkyProject/slurm-client/pkg/client/fake"
+	slurminterceptor "github.com/SlinkyProject/slurm-client/pkg/client/interceptor"
+	slurmobject "github.com/SlinkyProject/slurm-client/pkg/object"
+	slurmtypes "github.com/SlinkyProject/slurm-client/pkg/types"
+
+	"github.com/SlinkyProject/slurm-bridge/internal/runnable/slurmjob/slurmcontrol"
+	"github.com/SlinkyProject/slurm-bridge/internal/utils/externaljobinfo"
+	"github.com/SlinkyProject/slurm-bridge/internal/wellknown"
+)
+
+func bridgeJob(t *testing.T, id int32, nodes string, state slurmapi.V0044JobInfoJobState, pods ...string) slurmtypes.V0044JobInfo {
+	t.Helper()
+	extInfo := externaljobinfo.ExternalJobInfo{Pods: pods}
+	return slurmtypes.V0044JobInfo{V0044JobInfo: slurmapi.V0044JobInfo{
+		JobId:        ptr.To(id),
+		Nodes:        ptr.To(nodes),
+		JobState:     &[]slurmapi.V0044JobInfoJobState{state},
+		AdminComment: ptr.To(extInfo.ToString()),
+	}}
+}
+
+func metadataPod(name, jobId, nodeAnnotation, boundNode string) *corev1.Pod {
+	p := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      name,
+		Namespace: corev1.NamespaceDefault,
+	}}
+	if jobId != "" {
+		p.Labels = map[string]string{wellknown.LabelExternalJobId: jobId}
+	}
+	if nodeAnnotation != "" {
+		p.Annotations = map[string]string{wellknown.AnnotationExternalJobNode: nodeAnnotation}
+	}
+	p.Spec.NodeName = boundNode
+	return p
+}
+
+func TestSlurmJobRunnable_reconcilePodMetadata(t *testing.T) {
+	tests := []struct {
+		name           string
+		pod            *corev1.Pod
+		jobs           []slurmtypes.V0044JobInfo
+		wantLabel      string
+		wantAnnotation string
+	}{
+		{
+			name: "label rewritten when labeled job is gone",
+			pod:  metadataPod("pod1", "999", "", ""),
+			jobs: []slurmtypes.V0044JobInfo{
+				bridgeJob(t, 7, "", slurmapi.V0044JobInfoJobStatePENDING, "default/pod1"),
+			},
+			wantLabel: "7",
+		},
+		{
+			name: "label preserved while labeled job is alive",
+			pod:  metadataPod("pod1", "8", "", ""),
+			jobs: []slurmtypes.V0044JobInfo{
+				bridgeJob(t, 7, "", slurmapi.V0044JobInfoJobStatePENDING, "default/pod1"),
+				bridgeJob(t, 8, "", slurmapi.V0044JobInfoJobStatePENDING, "default/pod1-other"),
+			},
+			wantLabel: "8",
+		},
+		{
+			name: "annotation cleared when the job does not hold the node",
+			pod:  metadataPod("pod1", "7", "node9", ""),
+			jobs: []slurmtypes.V0044JobInfo{
+				bridgeJob(t, 7, "node1", slurmapi.V0044JobInfoJobStateRUNNING, "default/pod1"),
+			},
+			wantLabel:      "7",
+			wantAnnotation: "",
+		},
+		{
+			name: "annotation preserved when the job holds the node",
+			pod:  metadataPod("pod1", "7", "node1", ""),
+			jobs: []slurmtypes.V0044JobInfo{
+				bridgeJob(t, 7, "node1", slurmapi.V0044JobInfoJobStateRUNNING, "default/pod1"),
+			},
+			wantLabel:      "7",
+			wantAnnotation: "node1",
+		},
+		{
+			name: "bound pod annotation left alone",
+			pod:  metadataPod("pod1", "7", "node9", "kube-node-9"),
+			jobs: []slurmtypes.V0044JobInfo{
+				bridgeJob(t, 7, "node1", slurmapi.V0044JobInfoJobStateRUNNING, "default/pod1"),
+			},
+			wantLabel:      "7",
+			wantAnnotation: "node9",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kubeClient := fake.NewFakeClient(tt.pod)
+			jobList := &slurmtypes.V0044JobInfoList{Items: tt.jobs}
+			slurmClient := slurmclientfake.NewClientBuilder().WithLists(jobList).Build()
+			r := &SlurmJobRunnable{
+				Client:       kubeClient,
+				slurmControl: slurmcontrol.NewControl(slurmClient),
+			}
+
+			if err := r.reconcilePodMetadata(context.Background()); err != nil {
+				t.Fatalf("reconcilePodMetadata() error = %v", err)
+			}
+
+			got := &corev1.Pod{}
+			if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(tt.pod), got); err != nil {
+				t.Fatal(err)
+			}
+			if got.Labels[wellknown.LabelExternalJobId] != tt.wantLabel {
+				t.Errorf("label = %q, want %q", got.Labels[wellknown.LabelExternalJobId], tt.wantLabel)
+			}
+			if got.Annotations[wellknown.AnnotationExternalJobNode] != tt.wantAnnotation {
+				t.Errorf("annotation = %q, want %q", got.Annotations[wellknown.AnnotationExternalJobNode], tt.wantAnnotation)
+			}
+		})
+	}
+}
+
+// A live read of a missing job returns slurmrestd's raw not-found error
+// ("Not Found\nInvalid job id specified") rather than the typed
+// ErrObjectNotFound; the reconciler must still heal the pod.
+func TestSlurmJobRunnable_reconcilePodMetadata_RawNotFound(t *testing.T) {
+	pod := metadataPod("pod1", "999", "", "")
+	jobList := &slurmtypes.V0044JobInfoList{Items: []slurmtypes.V0044JobInfo{
+		bridgeJob(t, 7, "", slurmapi.V0044JobInfoJobStatePENDING, "default/pod1"),
+	}}
+	intercept := slurminterceptor.Funcs{
+		Get: func(ctx context.Context, key slurmobject.ObjectKey, obj slurmobject.Object, opts ...slurmclient.GetOption) error {
+			if string(key) == "999" {
+				// The realistic shape: an aggregate of status text plus
+				// slurmrestd's message.
+				return utilerrors.NewAggregate([]error{errors.New("Not Found"), errors.New("Invalid job id specified")})
+			}
+			return nil
+		},
+	}
+	slurmClient := slurmclientfake.NewClientBuilder().WithLists(jobList).WithInterceptorFuncs(intercept).Build()
+	kubeClient := fake.NewFakeClient(pod)
+	r := &SlurmJobRunnable{
+		Client:       kubeClient,
+		slurmControl: slurmcontrol.NewControl(slurmClient),
+	}
+	if err := r.reconcilePodMetadata(context.Background()); err != nil {
+		t.Fatalf("reconcilePodMetadata() error = %v", err)
+	}
+	got := &corev1.Pod{}
+	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(pod), got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Labels[wellknown.LabelExternalJobId] != "7" {
+		t.Errorf("label = %q, want healed to \"7\"", got.Labels[wellknown.LabelExternalJobId])
+	}
+}

--- a/internal/runnable/slurmjob/slurmjob_sync.go
+++ b/internal/runnable/slurmjob/slurmjob_sync.go
@@ -43,6 +43,10 @@ func (r *SlurmJobRunnable) Sync(ctx context.Context) error {
 		}
 	}
 
+	if err := r.reconcilePodMetadata(ctx); err != nil {
+		errs = append(errs, err)
+	}
+
 	return errors.Join(errs...)
 }
 

--- a/internal/scheduler/plugins/slurmbridge/slurmbridge.go
+++ b/internal/scheduler/plugins/slurmbridge/slurmbridge.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -21,7 +20,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -267,12 +265,6 @@ func (sb *SlurmBridge) PreFilter(ctx context.Context, state fwk.CycleState, pod 
 	s := &stateData{}
 	state.Write(stateKey, s)
 
-	// Populate podToJob representation to validate pod label and annotation
-	if err := sb.validatePodToJob(ctx, pod); err != nil {
-		logger.Error(err, "error validating pod against podToJob")
-		return nil, fwk.NewStatus(fwk.Error, err.Error())
-	}
-
 	// Construct an intermediate representation of the Slurm external job
 	s.slurmJobIR, err = slurmjobir.TranslateToSlurmJobIR(sb.Client, sb.draRegistry, ctx, pod)
 	if err != nil {
@@ -299,10 +291,30 @@ func (sb *SlurmBridge) PreFilter(ctx context.Context, state fwk.CycleState, pod 
 	node := pod.Annotations[wellknown.AnnotationExternalJobNode]
 	jobID := pod.Labels[wellknown.LabelExternalJobId]
 	if jobID != "" && node != "" {
-		sb.markPodGroupScheduled(ctx, s.slurmJobIR, jobID)
-		phNode := make(sets.Set[string])
-		phNode.Insert(node)
-		return &fwk.PreFilterResult{NodeNames: phNode}, fwk.NewStatus(fwk.Success)
+		// Confirm the external job still holds the annotated node before
+		// trusting the annotation, so the pod cannot bind to a node its
+		// job no longer holds.
+		annotatedJob, err := sb.slurmControl.GetJob(ctx, pod)
+		if err != nil {
+			return nil, fwk.NewStatus(fwk.Error, err.Error())
+		}
+		annotatedNodes, _ := hostlist.Expand(annotatedJob.Nodes)
+		if annotatedJob.JobId != 0 && slices.Contains(annotatedNodes, node) {
+			sb.markPodGroupScheduled(ctx, s.slurmJobIR, jobID)
+			phNode := make(sets.Set[string])
+			phNode.Insert(node)
+			return &fwk.PreFilterResult{NodeNames: phNode}, fwk.NewStatus(fwk.Success)
+		}
+		// Stale annotation: clear it and fall through to the normal flow.
+		logger.V(3).Info("Pod node annotation names a node its job does not hold; clearing",
+			"pod", klog.KObj(pod), "node", node)
+		toUpdate := pod.DeepCopy()
+		toUpdate.Annotations[wellknown.AnnotationExternalJobNode] = ""
+		if err := sb.Patch(ctx, toUpdate, client.StrategicMergeFrom(pod)); err != nil {
+			logger.Error(err, "failed to clear stale node annotation")
+			return nil, fwk.NewStatus(fwk.Error, ErrorPodUpdateFailed.Error())
+		}
+		pod.Annotations[wellknown.AnnotationExternalJobNode] = ""
 	}
 
 	// Determine if an external job for the pod exists in Slurm
@@ -424,6 +436,24 @@ func (sb *SlurmBridge) PostFilter(ctx context.Context, state fwk.CycleState, pod
 	// If no external job exists, we should create one with the list
 	// of nodes that passed Filter plugins.
 	if externalJob.JobId == 0 {
+		// A job claiming this pod may already exist without the pod's label
+		// referencing it. Adopt it rather than submitting a duplicate
+		// external job. This is the only path that lists every Slurm job,
+		// and it only runs when a job is about to be created.
+		podToJob, err := sb.slurmControl.GetJobsForPods(ctx)
+		if err != nil {
+			logger.Error(err, "error listing jobs before submit")
+			return nil, fwk.NewStatus(fwk.Error, err.Error())
+		}
+		if claimed, ok := (*podToJob)[pod.Namespace+"/"+pod.Name]; ok && claimed.JobId != 0 {
+			logger.Info("adopting existing external job for pod",
+				"pod", klog.KObj(pod), "jobId", claimed.JobId)
+			if err := sb.labelPodsWithJobId(ctx, claimed.JobId, s.slurmJobIR); err != nil {
+				return nil, fwk.NewStatus(fwk.Error, err.Error())
+			}
+			sb.activatePod(logger, pod)
+			return nil, fwk.NewStatus(fwk.Success)
+		}
 		jobid, err := sb.slurmControl.SubmitJob(ctx, pod, s.slurmJobIR)
 		if err != nil {
 			invalidConfigErr := findMatchingError(err, func(err error) bool {
@@ -671,48 +701,4 @@ func (sb *SlurmBridge) Filter(ctx context.Context, state fwk.CycleState, pod *co
 		return fwk.NewStatus(fwk.Success, "")
 	}
 	return fwk.NewStatus(fwk.Unschedulable, "node does not match annotation")
-}
-
-func (sb *SlurmBridge) validatePodToJob(ctx context.Context, pod *corev1.Pod) error {
-	logger := klog.FromContext(ctx)
-	logger.V(5).Info("validatePodToJob func", "pod", klog.KObj(pod))
-	namespacedName := types.NamespacedName{
-		Name:      pod.Name,
-		Namespace: pod.Namespace,
-	}
-	podToJob, err := sb.slurmControl.GetJobsForPods(ctx)
-	if err != nil {
-		logger.Error(err, "error populating podToJob")
-		return err
-	}
-	if val, ok := (*podToJob)[namespacedName.String()]; ok {
-		toUpdate := pod.DeepCopy()
-		// If the pod has a JobId set, validate it against podToJob
-		if pod.Labels[wellknown.LabelExternalJobId] != "" &&
-			val.JobId != slurmjobir.ParseSlurmJobId(pod.Labels[wellknown.LabelExternalJobId]) {
-			logger.V(3).Info("Pod jobId label does not match Slurm", "pod", klog.KObj(pod),
-				"jobId label", pod.Labels[wellknown.LabelExternalJobId],
-				"slurm job", val)
-			toUpdate.Labels[wellknown.LabelExternalJobId] = strconv.Itoa(int(val.JobId))
-		}
-		// If the pod has a Node set, validate it against podToJob
-		nodes, _ := hostlist.Expand(val.Nodes)
-		if pod.Annotations[wellknown.AnnotationExternalJobNode] != "" &&
-			!slices.Contains(nodes, pod.Annotations[wellknown.AnnotationExternalJobNode]) {
-			logger.V(3).Info("Pod node annotation does not match Slurm nodes", "pod", klog.KObj(pod),
-				"node annotation", pod.Annotations[wellknown.AnnotationExternalJobNode],
-				"slurm job", val)
-			toUpdate.Annotations[wellknown.AnnotationExternalJobNode] = ""
-		}
-		if !reflect.DeepEqual(pod, toUpdate) {
-			if err := sb.Patch(ctx, toUpdate, client.StrategicMergeFrom(pod)); err != nil {
-				logger.Error(err, "failed to update pod with slurm job id")
-				return ErrorPodUpdateFailed
-			}
-			// Update pod to reflect patch
-			pod.Labels[wellknown.LabelExternalJobId] = toUpdate.Labels[wellknown.LabelExternalJobId]
-			pod.Annotations[wellknown.AnnotationExternalJobNode] = toUpdate.Annotations[wellknown.AnnotationExternalJobNode]
-		}
-	}
-	return nil
 }

--- a/internal/scheduler/plugins/slurmbridge/slurmbridge_test.go
+++ b/internal/scheduler/plugins/slurmbridge/slurmbridge_test.go
@@ -1407,174 +1407,146 @@ func TestSlurmBridge_deleteExternalJob(t *testing.T) {
 	}
 }
 
-func TestSlurmBridge_validatePodToJob(t *testing.T) {
-	pod := st.MakePod().Name("pod1").Labels(map[string]string{wellknown.LabelExternalJobId: "1"}).Obj()
-	type fields struct {
-		Client       kubeclient.Client
-		slurmControl slurmcontrol.SlurmControlInterface
-		handle       fwk.Handle
+// PreFilter must confirm the node annotation against the external job and
+// clear it when the job no longer holds that node.
+func TestSlurmBridge_PreFilterAnnotationLiveCheck(t *testing.T) {
+	ctx := context.Background()
+	cs := clientsetfake.NewClientset()
+	informerFactory := informers.NewSharedInformerFactory(cs, 0)
+	registeredPlugins := []tf.RegisterPluginFunc{
+		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
 	}
-	type args struct {
-		ctx context.Context
-		pod *corev1.Pod
+	f, err := tf.NewFramework(ctx, registeredPlugins, "slurm-bridge",
+		fwkruntime.WithInformerFactory(informerFactory))
+	if err != nil {
+		t.Fatal(err)
 	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    *corev1.Pod
-		wantErr bool
-	}{
-		{
-			name: "Fail to get jobs",
-			fields: fields{
-				Client: kubefake.NewFakeClient(),
-				slurmControl: func() slurmcontrol.SlurmControlInterface {
-					f := interceptor.Funcs{
-						List: func(ctx context.Context, list object.ObjectList, opts ...slurmclient.ListOption) error {
-							return ErrorNoKubeNode
-						},
-					}
-					c := fake.NewClientBuilder().
-						WithInterceptorFuncs(f).
-						Build()
-					return slurmcontrol.NewControl(c, "kubernetes", "slurm-bridge")
-				}(),
-				handle: nil,
-			},
-			args: args{
-				ctx: context.TODO(),
-				pod: pod.DeepCopy(),
-			},
-			want:    pod.DeepCopy(),
-			wantErr: true,
-		},
-		{
-			name: "Matching slurm job exists",
-			fields: fields{
-				Client: kubefake.NewFakeClient(),
-				slurmControl: func() slurmcontrol.SlurmControlInterface {
-					list := &types.V0044JobInfoList{
-						Items: []types.V0044JobInfo{
-							{V0044JobInfo: api.V0044JobInfo{
-								AdminComment: func() *string {
-									pi := externaljobinfo.ExternalJobInfo{
-										Pods: []string{"/pod1"},
-									}
-									return ptr.To(pi.ToString())
-								}(),
-								JobId: ptr.To[int32](1),
-								Nodes: ptr.To(""),
-							}},
-						},
-					}
-					c := fake.NewClientBuilder().
-						WithLists(list).
-						Build()
-					return slurmcontrol.NewControl(c, "kubernetes", "slurm-bridge")
-				}(),
-				handle: nil,
-			},
-			args: args{
-				ctx: context.TODO(),
-				pod: pod.DeepCopy(),
-			},
-			want:    pod.DeepCopy(),
-			wantErr: false,
-		},
-		{
-			name: "Matching slurm job does not exist but patch fails",
-			fields: fields{
-				Client: kubefake.NewFakeClient(),
-				slurmControl: func() slurmcontrol.SlurmControlInterface {
-					list := &types.V0044JobInfoList{
-						Items: []types.V0044JobInfo{
-							{V0044JobInfo: api.V0044JobInfo{
-								AdminComment: func() *string {
-									pi := externaljobinfo.ExternalJobInfo{
-										Pods: []string{"/pod1"},
-									}
-									return ptr.To(pi.ToString())
-								}(),
-								JobId: ptr.To[int32](2),
-								Nodes: ptr.To(""),
-							}},
-						},
-					}
-					c := fake.NewClientBuilder().
-						WithLists(list).
-						Build()
-					return slurmcontrol.NewControl(c, "kubernetes", "slurm-bridge")
-				}(),
-				handle: nil,
-			},
-			args: args{
-				ctx: context.TODO(),
-				pod: pod.DeepCopy(),
-			},
-			want:    pod.DeepCopy(),
-			wantErr: true,
-		},
-		{
-			name: "Matching slurm job does not exist",
-			fields: fields{
-				Client: kubefake.NewFakeClient(pod),
-				slurmControl: func() slurmcontrol.SlurmControlInterface {
-					list := &types.V0044JobInfoList{
-						Items: []types.V0044JobInfo{
-							{V0044JobInfo: api.V0044JobInfo{
-								AdminComment: func() *string {
-									pi := externaljobinfo.ExternalJobInfo{
-										Pods: []string{"/pod1"},
-									}
-									return ptr.To(pi.ToString())
-								}(),
-								JobId: ptr.To[int32](2),
-								Nodes: ptr.To(""),
-							}},
-						},
-					}
-					c := fake.NewClientBuilder().
-						WithLists(list).
-						Build()
-					return slurmcontrol.NewControl(c, "kubernetes", "slurm-bridge")
-				}(),
-				handle: nil,
-			},
-			args: args{
-				ctx: context.TODO(),
-				pod: func() *corev1.Pod {
-					pod.Annotations = map[string]string{
-						wellknown.AnnotationExternalJobNode: "node2",
-					}
-					return pod.DeepCopy()
-				}(),
-			},
-			want: func() *corev1.Pod {
-				pod.Annotations = map[string]string{
-					wellknown.AnnotationExternalJobNode: "",
-				}
-				pod.Labels = map[string]string{
-					wellknown.LabelExternalJobId: "2",
-				}
-				return pod.DeepCopy()
+
+	makePod := func() *corev1.Pod {
+		return st.MakePod().Name("pod1").
+			Labels(map[string]string{wellknown.LabelExternalJobId: "1"}).
+			Annotations(map[string]string{wellknown.AnnotationExternalJobNode: "node2"}).Obj()
+	}
+	newControl := func(state api.V0044JobInfoJobState, nodes string) slurmcontrol.SlurmControlInterface {
+		jobs := &types.V0044JobInfoList{Items: []types.V0044JobInfo{
+			{V0044JobInfo: api.V0044JobInfo{
+				JobId:    ptr.To[int32](1),
+				JobState: &[]api.V0044JobInfoJobState{state},
+				Nodes:    ptr.To(nodes),
+			}},
+		}}
+		c := fake.NewClientBuilder().WithLists(jobs).Build()
+		return slurmcontrol.NewControl(c, "kubernetes", "slurm-bridge")
+	}
+
+	t.Run("annotation preserved when the live job holds the node", func(t *testing.T) {
+		pod := makePod()
+		sb := &SlurmBridge{
+			Client:       kubefake.NewFakeClient(pod.DeepCopy()),
+			slurmControl: newControl(api.V0044JobInfoJobStateRUNNING, "node2"),
+			handle:       f,
+		}
+		result, status := sb.PreFilter(ctx, framework.NewCycleState(), pod, nil)
+		if !status.IsSuccess() {
+			t.Fatalf("PreFilter() status = %v, want Success", status)
+		}
+		if result == nil || !result.NodeNames.Has("node2") {
+			t.Fatalf("PreFilter() result = %v, want early return with node2", result)
+		}
+	})
+
+	t.Run("stale annotation cleared when the job is gone", func(t *testing.T) {
+		pod := makePod()
+		sb := &SlurmBridge{
+			Client:       kubefake.NewFakeClient(pod.DeepCopy()),
+			slurmControl: newControl(api.V0044JobInfoJobStateCANCELLED, "node2"),
+			handle:       f,
+		}
+		result, status := sb.PreFilter(ctx, framework.NewCycleState(), pod, nil)
+		if !status.IsSuccess() {
+			t.Fatalf("PreFilter() status = %v, want Success (fall-through)", status)
+		}
+		if result != nil {
+			t.Fatalf("PreFilter() result = %v, want nil (no early return on stale annotation)", result)
+		}
+		if pod.Annotations[wellknown.AnnotationExternalJobNode] != "" {
+			t.Errorf("annotation = %q, want cleared", pod.Annotations[wellknown.AnnotationExternalJobNode])
+		}
+	})
+}
+
+// PostFilter must adopt an existing job that claims the pod instead of
+// submitting a duplicate external job.
+func TestSlurmBridge_PostFilterAdoptsExistingJob(t *testing.T) {
+	ctx := context.Background()
+	pod := st.MakePod().Name("pod1").Obj() // no job-id label
+	cs := clientsetfake.NewClientset()
+	informerFactory := informers.NewSharedInformerFactory(cs, 0)
+	registeredPlugins := []tf.RegisterPluginFunc{
+		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+	}
+	activator := &activateRecorder{}
+	f, err := tf.NewFramework(ctx, registeredPlugins, "slurm-bridge",
+		fwkruntime.WithInformerFactory(informerFactory),
+		fwkruntime.WithPodActivator(activator),
+		fwkruntime.WithSnapshotSharedLister(internalcache.NewSnapshot(
+			[]*corev1.Pod{pod},
+			[]*corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}})))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	jobs := &types.V0044JobInfoList{Items: []types.V0044JobInfo{
+		{V0044JobInfo: api.V0044JobInfo{
+			JobId:    ptr.To[int32](5),
+			JobState: &[]api.V0044JobInfoJobState{api.V0044JobInfoJobStatePENDING},
+			Nodes:    ptr.To(""),
+			AdminComment: func() *string {
+				pi := externaljobinfo.ExternalJobInfo{Pods: []string{"/pod1"}}
+				return ptr.To(pi.ToString())
 			}(),
-			wantErr: false,
+		}},
+	}}
+	nodes := &types.V0044NodeList{Items: []types.V0044Node{
+		{V0044Node: api.V0044Node{Name: ptr.To("node1")}},
+	}}
+	intercept := interceptor.Funcs{
+		Create: func(ctx context.Context, obj object.Object, req any, opts ...slurmclient.CreateOption) error {
+			t.Error("SubmitJob called: expected adoption of the existing job, not a duplicate submit")
+			return errors.New("unexpected create")
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			sb := &SlurmBridge{
-				Client:       tt.fields.Client,
-				slurmControl: tt.fields.slurmControl,
-				handle:       tt.fields.handle,
-			}
-			if err := sb.validatePodToJob(tt.args.ctx, tt.args.pod); (err != nil) != tt.wantErr {
-				t.Errorf("SlurmBridge.validatePodToJob() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if !apiequality.Semantic.DeepEqual(tt.args.pod, tt.want) {
-				t.Errorf("SlurmBridge.validatePodToJob() pod = %v, want %v", tt.args.pod, tt.want)
-			}
-		})
+	c := fake.NewClientBuilder().WithLists(jobs, nodes).WithInterceptorFuncs(intercept).Build()
+
+	kubeClient := kubefake.NewFakeClient(pod.DeepCopy())
+	sb := &SlurmBridge{
+		Client:       kubeClient,
+		slurmControl: slurmcontrol.NewControl(c, "kubernetes", "slurm-bridge"),
+		handle:       f,
+	}
+	state := framework.NewCycleState()
+	s := &stateData{}
+	s.slurmJobIR, _ = slurmjobir.TranslateToSlurmJobIR(kubeClient, sb.draRegistry, ctx, pod)
+	state.Write(stateKey, s)
+
+	m := framework.NewNodeToStatus(map[string]*fwk.Status{
+		"node1": fwk.NewStatus(fwk.Unschedulable).WithPlugin(Name),
+	}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable))
+
+	_, status := sb.PostFilter(ctx, state, pod, m)
+	if !status.IsSuccess() {
+		t.Fatalf("PostFilter() status = %v, want Success", status)
+	}
+	if len(activator.pods) == 0 {
+		t.Error("pod was not activated after adoption")
+	}
+	got := &corev1.Pod{}
+	if err := kubeClient.Get(ctx, kubeclient.ObjectKeyFromObject(pod), got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Labels[wellknown.LabelExternalJobId] != "5" {
+		t.Errorf("pod label = %q, want adopted job id \"5\"", got.Labels[wellknown.LabelExternalJobId])
 	}
 }

--- a/internal/scheduler/plugins/slurmbridge/slurmcontrol/slurmcontrol.go
+++ b/internal/scheduler/plugins/slurmbridge/slurmcontrol/slurmcontrol.go
@@ -5,7 +5,6 @@ package slurmcontrol
 
 import (
 	"context"
-	"net/http"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
@@ -17,6 +16,7 @@ import (
 	"github.com/SlinkyProject/slurm-client/pkg/object"
 	slurmtypes "github.com/SlinkyProject/slurm-client/pkg/types"
 
+	"github.com/SlinkyProject/slurm-bridge/internal/utils"
 	"github.com/SlinkyProject/slurm-bridge/internal/utils/externaljobinfo"
 	"github.com/SlinkyProject/slurm-bridge/internal/utils/slurmjobir"
 	"github.com/SlinkyProject/slurm-bridge/internal/wellknown"
@@ -131,7 +131,9 @@ func (r *realSlurmControl) GetJob(ctx context.Context, pod *corev1.Pod) (*Extern
 
 	err := r.Get(ctx, jobId, job)
 	if err != nil {
-		if err.Error() == http.StatusText(http.StatusNotFound) {
+		// A missing job is a normal outcome: the pod's labeled job is gone
+		// and the caller will adopt an existing job or submit a new one.
+		if utils.IsSlurmJobNotFoundErr(err) {
 			return &jobOut, nil
 		}
 		logger.Error(err, "could not get job for pod", "pod", klog.KObj(pod))

--- a/internal/utils/slurmerrors.go
+++ b/internal/utils/slurmerrors.go
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	slurmerrors "github.com/SlinkyProject/slurm-client/pkg/errors"
+)
+
+// IsSlurmJobNotFoundErr reports whether err means the requested Slurm job
+// does not exist. Cached reads return the typed ErrObjectNotFound; direct
+// API reads return an aggregate whose elements are the HTTP status text
+// (e.g. "Not Found") and slurmrestd's own messages (e.g. "Invalid job id
+// specified"). Elements are compared whole, never by substring, so an
+// unrelated error that merely contains "not found" is not misclassified
+// as a missing job.
+func IsSlurmJobNotFoundErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, slurmerrors.ErrObjectNotFound) {
+		return true
+	}
+	found := false
+	walkErrors(err, func(e error) {
+		// Compare whole lines, never substrings: aggregates carry one
+		// message per element, but some paths flatten them into a single
+		// newline-joined string.
+		for _, line := range strings.Split(e.Error(), "\n") {
+			line = strings.TrimSpace(line)
+			if line == http.StatusText(http.StatusNotFound) ||
+				strings.EqualFold(line, "invalid job id specified") {
+				found = true
+			}
+		}
+	})
+	return found
+}
+
+// walkErrors visits err and every error reachable through Unwrap.
+func walkErrors(err error, visit func(error)) {
+	if err == nil {
+		return
+	}
+	visit(err)
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, child := range joined.Unwrap() {
+			walkErrors(child, visit)
+		}
+		return
+	}
+	if agg, ok := err.(interface{ Errors() []error }); ok {
+		for _, child := range agg.Errors() {
+			walkErrors(child, visit)
+		}
+		return
+	}
+	walkErrors(errors.Unwrap(err), visit)
+}

--- a/internal/utils/slurmerrors_test.go
+++ b/internal/utils/slurmerrors_test.go
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	slurmerrors "github.com/SlinkyProject/slurm-client/pkg/errors"
+)
+
+func TestIsSlurmJobNotFoundErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "typed cache error", err: slurmerrors.ErrObjectNotFound, want: true},
+		{name: "wrapped typed error", err: fmt.Errorf("get job: %w", slurmerrors.ErrObjectNotFound), want: true},
+		{name: "plain 404 status text", err: errors.New("Not Found"), want: true},
+		{
+			// The shape slurm-client's direct reads produce.
+			name: "direct-read aggregate 404",
+			err:  utilerrors.NewAggregate([]error{errors.New("Not Found"), errors.New("Invalid job id specified")}),
+			want: true,
+		},
+		{name: "slurmctld invalid job id alone", err: errors.New("Invalid job id specified"), want: true},
+		{name: "flattened newline-joined form", err: errors.New("Not Found\nInvalid job id specified"), want: true},
+		{name: "unrelated error", err: errors.New("connection refused"), want: false},
+		{
+			// A substring match must not classify an unrelated error.
+			name: "substring not found in transient error",
+			err:  errors.New("dial tcp: lookup slurm-restapi: host not found"),
+			want: false,
+		},
+		{
+			name: "aggregate 5xx with unrelated message",
+			err:  utilerrors.NewAggregate([]error{errors.New("Internal Server Error"), errors.New("upstream not found")}),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsSlurmJobNotFoundErr(tt.err); got != tt.want {
+				t.Errorf("IsSlurmJobNotFoundErr(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION

## Summary

Related to #45.

`validatePodToJob` previously fetched and JSON-decoded the entire slurmrestd `/jobs` listing and rebuilt a pod->job map on every scheduling cycle, in order to make two rare drift corrections: 

1. rewrite a pod's external-job-id label when another bridge job claims the pod
2. clear a pod's node annotation when its job doesn't hold that node

On large clusters the listing can easily exceed 30 MB (roughly 900 jobs), and results in a fetch-and-decode taking 1.4s. The scheduler pays this cost on each attempt for corrections that rarely fire. Because the scheduling loop is serial, the per-attempt cost is what turns "some pods are waiting for Slurm capacity" into "lower-priority pods never get scheduled at all" (https://github.com/SlinkyProject/slurm-bridge/issues/45).

This PR removes the per-cycle listing entirely and relocates the reconciliation to where control-loop already exists:

- **Periodic healing moves to the controllers.** The existing `slurmjob` runnable already walks every bridge job's admin comment on a 30s cadence. Now it also heals pod metadata there: rewrite the job-id label when the labeled job is gone from Slurm but another bridge job claims the pod, and clear the node annotation (unbound pods only) when the pod's job does not hold that node.
- **Two safeguards stay inline in the scheduler**
  - *Adopt-don't-duplicate on the submit path*: when PostFilter is about to create a job, it first consults the job listing once and adopts an existing job that claims the pod instead of submitting a duplicate. This is now the only place the scheduler lists jobs, and it runs per job creation instead of per cycle. It also closes a pre-existing hole: a pod whose label patch failed after submit used to duplicate-submit, because the old reconciliation only corrected non-empty labels.
  - *Live annotation check on the PreFilter fast path*: the early return that trusts the node annotation now confirms it against a single-job read, so a scheduling pod cannot bind to a node its job no longer holds while waiting for the periodic heal.
- **Not-found classification** (found by live testing): slurm-client's direct API reads return an aggregate error whose first element is the HTTP status text (e.g. `"Not Found"` followed by slurmrestd's `"Invalid job id specified"`), which matched neither the typed `ErrObjectNotFound` nor `GetJob`'s exact-string check. This was previously masked because the inline reconciliation healed labels before `GetJob` ever saw them.

Steady-state `/jobs` load drops from one full fetch **per scheduling attempt** to one per 30s (controllers) plus one per job creation.

## Validation

Starvation setup can be found on #45.

| Test | `main` (6e11918) | this PR |
|---|---|---|
| Low-priority pod under starvation load | never scheduled (12+ min, zero attempts, zero events) | **bound in 3 s**; ~50 ms attempt cadence; all 20 blocked pods submitted in 23 s |
| Corrupted job-id label, pending pod, scheduler scaled to 0 | n/a | **controller healed in 37 s** (one sync period) |
| Corrupted job-id label, pending pod, controllers scaled to 0 | n/a | **scheduler adopted the existing job in 4 s**; Slurm queue depth unchanged (no duplicate submit) |
| Stale node annotation on a scheduling pod | cleared, by the old per-cycle reconciliation | **cleared in 7 s**, by the single-job check the scheduler now runs before trusting the annotation |

## Checklist

- [x] I have read
  [CONTRIBUTING.md](https://github.com/SlinkyProject/slurm-bridge/blob/main/CONTRIBUTING.md)
  and the
  [Code of Conduct](https://github.com/SlinkyProject/slurm-bridge/blob/main/CODE_OF_CONDUCT.md).
- [x] New or existing tests cover these changes (where applicable).
- [x] Documentation is updated if user-visible behavior changes. <!-- no user-facing docs describe the reconciliation; happy to add a note to docs/ if maintainers want one -->

## Breaking Changes

None intended, with two visible behavior shifts:

- Label/annotation drift healing is now periodic (<= ~30s via the controllers) instead of inline-per-cycle for cases outside the two inline safeguards. The decisive cases keep inline timing: duplicate prevention happens at submit, and annotation trust is verified live before the fast-path return.
- The controllers now patch pod labels/annotations. Healing also now covers pods the previously inline code could never reach (it only ran for pods being actively scheduled).

## Testing Notes

- `go test ./internal/scheduler/... ./internal/runnable/...` has new unit tests: the controller reconciler (label heal on dead job, label preserved on live job, annotation clear/preserve, bound-pod skip, raw not-found error shape), scheduler adopt-on-submit (asserts no `Create` reaches Slurm), and the PreFilter annotation live check (preserve on live node, clear and fall-through on stale).
- Live validation. The drift tests isolate each component by scaling the other to zero.

### Scale testing vs `main`

We measured how many Slurm-blocked pods the scheduler can tolerate before other pods starve. Setup: N high-priority pods whose external jobs pend forever (one Slurm job each), plus 3000 held filler jobs so the `/jobs` listing is production-sized (27.7 MB). At each N we create one feasible low-priority pod and measure its time-to-bind; idle nodes are always available to it.

| Blocked pods | `main` (6e11918) | this PR |
|---|---|---|
| 0 | binds in 10 s | — |
| 5 | binds in 40 s | — |
| 10 | **starved** (>300 s, job never submitted) | — |
| 20 | **starved** (>300 s, job never submitted) | **binds in 5 s** |
| 100 | — | binds in 233 s |
| 150 | — | starved (>300 s) |


## Additional Context

- Why not cache the listing instead? We built and validated that too, but believe this implementation is simpler and less error-prone. Removing the per-cycle work outright keeps the hot path at zero list operations, moves reconciliation into the component that already owns job->pod lifecycle sweeps, and closes the empty-label duplicate-submit hole.
- To fully close #45, we believe a second change is warranted. When a pod's external job is waiting for Slurm capacity, `PostFilter` calls `activatePod()`, which guarantees the pod re-enters the active queue as soon as its scheduling backoff expires, and backoff is capped at `podMaxBackoffSeconds` (default 10s). This means every Slurm-blocked pod is retried at least once every 10s, instead of resting in the unschedulable pool the way other unschedulable pods do. The second change, which should scale from 100's to 1000's of blocked pods, is to return Unschedulable from the no-progress paths; register narrow EnqueueExtensions so blocked pods stop requeuing on unrelated cluster events; and have the controllers wake exactly the right pod when Slurm allocates its job